### PR TITLE
bugfix: some whitespaces disappear around substitution expressions

### DIFF
--- a/java-src/io/github/erdos/stencil/impl/ClojureHelper.java
+++ b/java-src/io/github/erdos/stencil/impl/ClojureHelper.java
@@ -24,9 +24,7 @@ public class ClojureHelper {
     /**
      * Clojure :template keyword
      */
-    public static final Keyword
-            KV_TEMPLATE = Keyword.intern("template");
-
+    public static final Keyword KV_TEMPLATE = Keyword.intern("template");
 
     /**
      * Clojure :data keyword
@@ -58,7 +56,6 @@ public class ClojureHelper {
     public static IFn findFunction(String functionName) {
         return RT.var("stencil.process", functionName);
     }
-
 
     /**
      * Shuts down clojure agents. Needed to speed up quitting from Clojure programs.

--- a/src/stencil/infix.clj
+++ b/src/stencil/infix.clj
@@ -146,7 +146,7 @@
 (defn- validate-tokens [tokens]
   (cond
     (some true? (map #(and (or (symbol? %1) (number? %1) (#{:close} %1))
-                         (or (symbol? %2) (number? %2) (#{:open} %2)))
+                           (or (symbol? %2) (number? %2) (#{:open} %2)))
                      tokens (next tokens)))
     (throw (ex-info "Could not parse!" {}))
 

--- a/src/stencil/merger.clj
+++ b/src/stencil/merger.clj
@@ -80,13 +80,13 @@
   (let [sts (text-split-tokens (:text (first token-list)))]
     (if (:action-part sts)
       ;; Ha van olyan akcio resz, amit elkezdtunk de nem irtunk vegig...
-      (let [next-token-list (cons {:text (:action-part sts)}
-                                  (next token-list))
-
+      (let [next-token-list (cons {:text (:action-part sts)} (next token-list))
             [this that] (split-with #(not= (seq close-tag)
                                            (take (count close-tag) (map :char %)))
                                     (suffixes (peek-next-text next-token-list)))
-            that           (first (nth that (dec (count close-tag))))
+            that        (if (empty? that)
+                          (throw (ex-info "Tag is not closed? " {:read (first this)}))
+                          (first (nth that (dec (count close-tag)))))
             action-content (apply str (map (comp :char first) this))]
         (assert (map? that)) ;; TODO: mi van ha nem lezarhato az elem?
         (concat

--- a/src/stencil/postprocess/delayed.clj
+++ b/src/stencil/postprocess/delayed.clj
@@ -4,6 +4,9 @@
             [stencil.util :refer :all]))
 
 (defn- dfs-walk-xml [xml-tree predicate edit-fn]
+  (assert (map? xml-tree))
+  (assert (fn? predicate))
+  (assert (fn? edit-fn))
   (loop [loc (xml-zip xml-tree)]
     (if (zip/end? loc)
       (zip/root loc)

--- a/src/stencil/postprocess/delayed.clj
+++ b/src/stencil/postprocess/delayed.clj
@@ -4,7 +4,6 @@
             [stencil.types :refer :all]
             [stencil.util :refer :all]))
 
-
 (defn- dfs-walk-xml [xml-tree predicate edit-fn]
   (assert (map? xml-tree))
   (assert (fn? predicate))

--- a/src/stencil/postprocess/delayed.clj
+++ b/src/stencil/postprocess/delayed.clj
@@ -1,7 +1,9 @@
 (ns stencil.postprocess.delayed
+  "Calls deref on delayed values in an XML tree."
   (:require [clojure.zip :as zip]
             [stencil.types :refer :all]
             [stencil.util :refer :all]))
+
 
 (defn- dfs-walk-xml [xml-tree predicate edit-fn]
   (assert (map? xml-tree))

--- a/src/stencil/postprocess/delayed.clj
+++ b/src/stencil/postprocess/delayed.clj
@@ -1,0 +1,17 @@
+(ns stencil.postprocess.delayed
+  (:require [clojure.zip :as zip]
+            [stencil.types :refer :all]
+            [stencil.util :refer :all]))
+
+(defn- dfs-walk-xml [xml-tree predicate edit-fn]
+  (loop [loc (xml-zip xml-tree)]
+    (if (zip/end? loc)
+      (zip/root loc)
+      (if (predicate (zip/node loc))
+        (recur (zip/next (zip/edit loc edit-fn)))
+        (recur (zip/next loc))))))
+
+(defn deref-delayed-values
+  "Walks the tree (Depth First) and evaluates DelayedValueMarker objects."
+  [xml-tree]
+  (dfs-walk-xml xml-tree (partial instance? clojure.lang.IDeref) deref))

--- a/src/stencil/postprocess/whitespaces.clj
+++ b/src/stencil/postprocess/whitespaces.clj
@@ -17,18 +17,17 @@
       (meta xml-tree))
     xml-tree))
 
-
 (def ooxml-t :xmlns.http%3A%2F%2Fschemas.openxmlformats.org%2Fwordprocessingml%2F2006%2Fmain/t)
 
 (defn- should-fix?
-  "We only fix <t> tags where the enclosed string starts or ends with a whitespace."
+  "We only fix <t> tags where the enclosed string starts or ends with whitespace."
   [element]
   (boolean
-   (when (map? element)
-     (when (= ooxml-t (:tag element))
-       (when (seq (:content element))
-         (or (.startsWith (str (first (:content element))) " ")
-            (.startsWith (str (last (:content element))) " ")))))))
+   (when (and (map? element)
+            (= ooxml-t (:tag element))
+            (seq (:content element)))
+     (or (.startsWith (str (first (:content element))) " ")
+        (.startsWith (str (last (:content element))) " ")))))
 
 (defn- fix-elem [element]
   (assoc-in element [:attrs "xml:space"] "preserve"))

--- a/src/stencil/postprocess/whitespaces.clj
+++ b/src/stencil/postprocess/whitespaces.clj
@@ -1,0 +1,38 @@
+(ns stencil.postprocess.whitespaces
+  (:require [clojure.zip :as zip]
+            [stencil.types :refer :all]
+            [stencil.util :refer :all]))
+
+;;
+;;
+;;
+;; http://officeopenxml.com/WPtext.php
+
+;; like clojure.walk/postwalk but keeps metadata and calls fn only on nodes
+(defn- postwalk-xml [f xml-tree]
+  (if (map? xml-tree)
+    (f (update xml-tree :content (partial mapv (partial postwalk-xml f))))
+    xml-tree))
+
+
+(def ooxml-t :xmlns.http%3A%2F%2Fschemas.openxmlformats.org%2Fwordprocessingml%2F2006%2Fmain/t)
+
+(def space-tag :xml/space)
+
+(def space-entry [:xml/space "preserve"])
+
+(defn- should-fix?
+  "We only fix <t> tags where the enclosed string starts or ends with a whitespace."
+  [element]
+  (boolean
+   (when (map? element)
+     (when (= ooxml-t (:tag element))
+       (when (seq (:content element))
+         (or (.startsWith (str (first (:content element))) " ")
+            (.startsWith (str (last (:content element))) " ")))))))
+
+(defn- fix-elem [element]
+  (assoc-in element [:attrs :xml/space] "preserve"))
+
+(defn fix-whitespaces [xml-tree]
+  (postwalk-xml #(if (should-fix? %) (fix-elem %) %) xml-tree))

--- a/src/stencil/postprocess/whitespaces.clj
+++ b/src/stencil/postprocess/whitespaces.clj
@@ -17,10 +17,6 @@
 
 (def ooxml-t :xmlns.http%3A%2F%2Fschemas.openxmlformats.org%2Fwordprocessingml%2F2006%2Fmain/t)
 
-(def space-tag :xml/space)
-
-(def space-entry [:xml/space "preserve"])
-
 (defn- should-fix?
   "We only fix <t> tags where the enclosed string starts or ends with a whitespace."
   [element]
@@ -32,7 +28,7 @@
             (.startsWith (str (last (:content element))) " ")))))))
 
 (defn- fix-elem [element]
-  (assoc-in element [:attrs :xml/space] "preserve"))
+  (assoc-in element [:attrs "xml:space"] "preserve"))
 
 (defn fix-whitespaces [xml-tree]
   (postwalk-xml #(if (should-fix? %) (fix-elem %) %) xml-tree))

--- a/src/stencil/postprocess/whitespaces.clj
+++ b/src/stencil/postprocess/whitespaces.clj
@@ -18,6 +18,7 @@
     xml-tree))
 
 (def ooxml-t :xmlns.http%3A%2F%2Fschemas.openxmlformats.org%2Fwordprocessingml%2F2006%2Fmain/t)
+(def ooxml-attr-space :xmlns.http%3A%2F%2Fwww.w3.org%2FXML%2F1998%2Fnamespace/space)
 
 (defn- should-fix?
   "We only fix <t> tags where the enclosed string starts or ends with whitespace."
@@ -30,7 +31,7 @@
         (.startsWith (str (last (:content element))) " ")))))
 
 (defn- fix-elem [element]
-  (assoc-in element [:attrs "xml:space"] "preserve"))
+  (assoc-in element [:attrs ooxml-attr-space] "preserve"))
 
 (defn fix-whitespaces [xml-tree]
   (postwalk-xml #(if (should-fix? %) (fix-elem %) %) xml-tree))

--- a/src/stencil/postprocess/whitespaces.clj
+++ b/src/stencil/postprocess/whitespaces.clj
@@ -9,9 +9,12 @@
 ;; http://officeopenxml.com/WPtext.php
 
 ;; like clojure.walk/postwalk but keeps metadata and calls fn only on nodes
+;; also: explicitly keeps meta data
 (defn- postwalk-xml [f xml-tree]
   (if (map? xml-tree)
-    (f (update xml-tree :content (partial mapv (partial postwalk-xml f))))
+    (with-meta
+      (f (update xml-tree :content (partial mapv (partial postwalk-xml f))))
+      (meta xml-tree))
     xml-tree))
 
 

--- a/src/stencil/postprocess/whitespaces.clj
+++ b/src/stencil/postprocess/whitespaces.clj
@@ -25,10 +25,10 @@
   [element]
   (boolean
    (when (and (map? element)
-            (= ooxml-t (:tag element))
-            (seq (:content element)))
+              (= ooxml-t (:tag element))
+              (seq (:content element)))
      (or (.startsWith (str (first (:content element))) " ")
-        (.startsWith (str (last (:content element))) " ")))))
+         (.startsWith (str (last (:content element))) " ")))))
 
 (defn- fix-elem [element]
   (assoc-in element [:attrs ooxml-attr-space] "preserve"))

--- a/src/stencil/process.clj
+++ b/src/stencil/process.clj
@@ -54,7 +54,6 @@
                                   :when (:dynamic? v)]
                               [k (:executable v)]))})))
 
-
 (defn- run-executable-and-return-writer
   "Returns a function that writes output to its output-stream parameter"
   [executable function data]

--- a/src/stencil/tree_postprocess.clj
+++ b/src/stencil/tree_postprocess.clj
@@ -1,22 +1,8 @@
 (ns stencil.tree-postprocess
-  "XML fa utofeldolgozasat vegzo kod."
-  (:require [clojure.zip :as zip]
+  "Postprocessing an xml tree"
+  (:require [stencil.postprocess.delayed :refer :all]
             [stencil.postprocess.table :refer :all]
-            [stencil.types :refer :all]
-            [stencil.util :refer :all]))
+            [stencil.postprocess.whitespaces :refer :all]))
 
-(set! *warn-on-reflection* true)
-
-(defn deref-delayed-values
-  "Walks the tree (Depth First) and evaluates DelayedValueMarker objects."
-  [xml-tree]
-  (loop [loc (xml-zip xml-tree)]
-    (if (zip/end? loc)
-      (zip/root loc)
-      (if (instance? clojure.lang.IDeref (zip/node loc))
-        (recur (zip/next (zip/edit loc deref)))
-        (recur (zip/next loc))))))
-
-(def postprocess (comp deref-delayed-values fix-tables))
-
-:ok
+;; calls postprocess steps
+(def postprocess (comp deref-delayed-values fix-tables fix-whitespaces))

--- a/src/stencil/tree_postprocess.clj
+++ b/src/stencil/tree_postprocess.clj
@@ -4,5 +4,5 @@
             [stencil.postprocess.table :refer :all]
             [stencil.postprocess.whitespaces :refer :all]))
 
-;; calls postprocess steps
+;; calls postprocess
 (def postprocess (comp deref-delayed-values fix-tables fix-whitespaces))

--- a/src/stencil/types.clj
+++ b/src/stencil/types.clj
@@ -38,7 +38,8 @@
 (defn hide-table-column-marker? [x] (instance? HideTableColumnMarker x))
 (defn hide-table-row-marker? [x] (instance? HideTableRowMarker x))
 
-;; ez a marker valamilyen kesleltetett erteket jelol.
+;; Function calls might return delayed values that are dereferenced
+;; only in the postprocess stage.
 (defrecord DelayedValueMarker [delay-object]
   clojure.lang.IDeref
   (deref [_] @delay-object))

--- a/test/stencil/api_test.clj
+++ b/test/stencil/api_test.clj
@@ -1,14 +1,9 @@
 (ns stencil.api-test
   (:require [stencil.api :refer :all]))
 
-(comment
+(comment (def template-1 (prepare "/home/erdos/Joy/stencil/test-resources/test-control-conditionals.docx"))
 
+         (defn render-template-1 [output-file data]
+           (render! template-1 data :output output-file))
 
-  (def template-1 (prepare "/home/erdos/Joy/stencil/test-resources/test-control-conditionals.docx"))
-
-  (defn render-template-1 [output-file data]
-    (render! template-1 data :output output-file))
-
-  (render-template-1 "/tmp/output-3.docx" {"customerName" "John Doe"})
-
-  )
+         (render-template-1 "/tmp/output-3.docx" {"customerName" "John Doe"}))

--- a/test/stencil/errors.clj
+++ b/test/stencil/errors.clj
@@ -1,0 +1,29 @@
+(ns stencil.errors
+  (:require [stencil.types :refer :all]
+            [clojure.test :refer [deftest is are testing]]
+            [stencil.process :refer :all]))
+
+(defn- test-prepare [xml-str data-map]
+  (->> xml-str
+     str
+     .getBytes
+     (new java.io.ByteArrayInputStream)
+     (prepare-template :xml)))
+
+(defmacro throw-ex-info? [expr]
+  `(is (~'thrown? clojure.lang.ExceptionInfo (test-prepare ~expr {}))))
+
+(deftest test-arithmetic-errors
+  (testing "Arithmetic errors"
+    (throw-ex-info? "<a>{%=%}</a>")
+    (throw-ex-info? "<a>{%=a++%}</a>")
+    (throw-ex-info? "<a>{%====%}</a>")))
+                                        ;
+(deftest test-not-closed
+  (testing "Expressions are not closed properly"
+    (throw-ex-info? "<a>{%=</a>")
+    (throw-ex-info? "<a>{%=x</a>")
+    (throw-ex-info? "<a>{%=x%</a>")
+    (throw-ex-info? "<a>{%=x}</a>"))
+  (testing "Middle expr is not closed"
+    (throw-ex-info? "<a><b>{%=1%}</b>{%=3<c>{%=4%}</c></a>")))

--- a/test/stencil/errors.clj
+++ b/test/stencil/errors.clj
@@ -5,10 +5,10 @@
 
 (defn- test-prepare [xml-str data-map]
   (->> xml-str
-     str
-     .getBytes
-     (new java.io.ByteArrayInputStream)
-     (prepare-template :xml)))
+       str
+       .getBytes
+       (new java.io.ByteArrayInputStream)
+       (prepare-template :xml)))
 
 (defmacro throw-ex-info? [expr]
   `(is (~'thrown? clojure.lang.ExceptionInfo (test-prepare ~expr {}))))

--- a/test/stencil/postprocess/whitespaces_test.clj
+++ b/test/stencil/postprocess/whitespaces_test.clj
@@ -1,0 +1,34 @@
+(ns stencil.postprocess.whitespaces-test
+  (:require [stencil.types :refer :all]
+            [clojure.test :refer [deftest is are testing]]
+            [clojure.data.xml :as xml]
+            [stencil.process :refer :all]))
+
+(defn- test-eval [xml-str data-map]
+  (let [prepared (->> xml-str
+                    str
+                    .getBytes
+                    (new java.io.ByteArrayInputStream)
+                    (prepare-template :xml))]
+    (-> {:template prepared
+        :data data-map
+        :function (fn [& _] (assert false "ERROR"))}
+       do-eval-stream :stream slurp str)))
+
+(defmacro ^:private test-equals [expected input data]
+  `(is (= (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" ~expected)
+          (test-eval ~input ~data))))
+
+(deftest test-whitespaces
+  (testing "xml space preserve is inserted for second <t> tag."
+    (test-equals
+     "<a:a xmlns:a=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\"><a:t>Sum: 1</a:t><a:t xml:space=\"preserve\"> pieces</a:t></a:a>"
+     "<x:a xmlns:x=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\"><x:t>Sum: {%=x </x:t><x:t>%} pieces</x:t></x:a>"
+     {"x" 1}))
+  (testing "existing space=preserve attributes are kept intact"
+    (test-equals
+     "<a:a xmlns:a=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\" xml:space=\"preserve\"> Hello </a:a>"
+     "<x:a xmlns:x=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\" xml:space=\"preserve\"> Hello </x:a>"
+     {})))
+
+;; (test-eval "<a>Sum:<b> {%=x </b>%} pieces</a>" {"x" 1})

--- a/test/stencil/postprocess/whitespaces_test.clj
+++ b/test/stencil/postprocess/whitespaces_test.clj
@@ -6,14 +6,14 @@
 
 (defn- test-eval [xml-str data-map]
   (let [prepared (->> xml-str
-                    str
-                    .getBytes
-                    (new java.io.ByteArrayInputStream)
-                    (prepare-template :xml))]
+                      str
+                      .getBytes
+                      (new java.io.ByteArrayInputStream)
+                      (prepare-template :xml))]
     (-> {:template prepared
-        :data data-map
-        :function (fn [& _] (assert false "ERROR"))}
-       do-eval-stream :stream slurp str)))
+         :data data-map
+         :function (fn [& _] (assert false "ERROR"))}
+        do-eval-stream :stream slurp str)))
 
 (defmacro ^:private test-equals [expected input data]
   `(is (= (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" ~expected)

--- a/test/stencil/process_test.clj
+++ b/test/stencil/process_test.clj
@@ -19,23 +19,5 @@
   `(is (= (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" ~expected)
           (test-eval ~input ~data))))
 
-                                        ; (test-eval "<a> <b> </b> </a>" {})
-
-;; TODO: we should have something for space:preserve notations.
-
 (deftest simple-substitution
   (test-equals "<a>3</a>" "<a>{%=x%}</a>" {"x" 3}))
-
-(deftest test-whitespaces
-  (testing "xml space preserve is inserted"
-    (test-equals
-     "<a>Sum:<b> 1</b> pieces</a>"
-     "<a xmlns:x=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\">Sum:<x:t> {%=x </x:t>%} pieces</a>"
-     {"x" 1})
-
-    #_(test-equals
-     "<a>Sum: 1<b xml:space=\"preserve\"> pieces</b></a>"
-     "<a>Sum: {%=x <b>%} pieces</b></a>"
-     {"x" 1})))
-
-;; (test-eval "<a>Sum:<b> {%=x </b>%} pieces</a>" {"x" 1})

--- a/test/stencil/process_test.clj
+++ b/test/stencil/process_test.clj
@@ -1,0 +1,23 @@
+(ns stencil.process-test
+  (:require [stencil.types :refer :all]
+            [clojure.test :refer [deftest is are testing]]
+            [clojure.data.xml :as xml]
+            [stencil.process :refer :all]))
+
+(defn- test-eval [xml-str data-map]
+  (let [prepared (->> xml-str
+                    str
+                    .getBytes
+                    (new java.io.ByteArrayInputStream)
+                    (prepare-template :xml))]
+    (-> {:template prepared
+        :data data-map
+        :function (fn [& _] (assert false "ERROR"))}
+       do-eval-stream :stream slurp str)))
+
+(defmacro ^:private test-equals [expected input data]
+  `(is (= (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" ~expected)
+          (test-eval ~input ~data))))
+
+(deftest simple-substitution
+  (test-equals "<a>3</a>" "<a>{%=x%}</a>" {"x" 3}))

--- a/test/stencil/process_test.clj
+++ b/test/stencil/process_test.clj
@@ -6,14 +6,14 @@
 
 (defn- test-eval [xml-str data-map]
   (let [prepared (->> xml-str
-                    str
-                    .getBytes
-                    (new java.io.ByteArrayInputStream)
-                    (prepare-template :xml))]
+                      str
+                      .getBytes
+                      (new java.io.ByteArrayInputStream)
+                      (prepare-template :xml))]
     (-> {:template prepared
-        :data data-map
-        :function (fn [& _] (assert false "ERROR"))}
-       do-eval-stream :stream slurp str)))
+         :data data-map
+         :function (fn [& _] (assert false "ERROR"))}
+        do-eval-stream :stream slurp str)))
 
 (defmacro ^:private test-equals [expected input data]
   `(is (= (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" ~expected)

--- a/test/stencil/process_test.clj
+++ b/test/stencil/process_test.clj
@@ -30,10 +30,10 @@
   (testing "xml space preserve is inserted"
     (test-equals
      "<a>Sum:<b> 1</b> pieces</a>"
-     "<a>Sum:<b> {%=x </b>%} pieces</a>"
+     "<a xmlns:x=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\">Sum:<x:t> {%=x </x:t>%} pieces</a>"
      {"x" 1})
 
-    (test-equals
+    #_(test-equals
      "<a>Sum: 1<b xml:space=\"preserve\"> pieces</b></a>"
      "<a>Sum: {%=x <b>%} pieces</b></a>"
      {"x" 1})))

--- a/test/stencil/process_test.clj
+++ b/test/stencil/process_test.clj
@@ -25,3 +25,17 @@
 
 (deftest simple-substitution
   (test-equals "<a>3</a>" "<a>{%=x%}</a>" {"x" 3}))
+
+(deftest test-whitespaces
+  (testing "xml space preserve is inserted"
+    (test-equals
+     "<a>Sum:<b> 1</b> pieces</a>"
+     "<a>Sum:<b> {%=x </b>%} pieces</a>"
+     {"x" 1})
+
+    (test-equals
+     "<a>Sum: 1<b xml:space=\"preserve\"> pieces</b></a>"
+     "<a>Sum: {%=x <b>%} pieces</b></a>"
+     {"x" 1})))
+
+;; (test-eval "<a>Sum:<b> {%=x </b>%} pieces</a>" {"x" 1})

--- a/test/stencil/process_test.clj
+++ b/test/stencil/process_test.clj
@@ -19,5 +19,9 @@
   `(is (= (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" ~expected)
           (test-eval ~input ~data))))
 
+                                        ; (test-eval "<a> <b> </b> </a>" {})
+
+;; TODO: we should have something for space:preserve notations.
+
 (deftest simple-substitution
   (test-equals "<a>3</a>" "<a>{%=x%}</a>" {"x" 3}))

--- a/test/stencil/tree_postprocess_test.clj
+++ b/test/stencil/tree_postprocess_test.clj
@@ -84,7 +84,7 @@
     (is (=
          (table (row (cell "X1") (cell "X3")) (row (cell "Y1") (cell "Y3")))
          (fix-tables (table (row (cell "X1") (cell-of-width 2 "X2" (->HideTableColumnMarker)) (cell "X3"))
-                             (row (cell "Y1") (cell-of-width 2 "Y2") (cell "Y3"))))))))
+                            (row (cell "Y1") (cell-of-width 2 "Y2") (cell "Y3"))))))))
 
 (deftest test-preprocess-remove-thin-cols
   (testing "There are infinitely thin columns that are being removed."
@@ -164,7 +164,7 @@
       (is (=  (into-hiccup (table (row (cell border-1 "ALMA"))
                                   (row (cell border-2 "NARANCS"))))
               (into-hiccup (fix-tables (table (row (cell "ALMA") (cell border-1 (->HideTableColumnMarker) "KORTE"))
-                                               (row (cell "NARANCS") (cell border-2 "BARACK"))))))))))
+                                              (row (cell "NARANCS") (cell border-2 "BARACK"))))))))))
 
 (deftest resize-rational-2
   (is (= '(nil {:attrs {:x 1}, :tag :right})

--- a/test/stencil/tree_postprocess_test.clj
+++ b/test/stencil/tree_postprocess_test.clj
@@ -27,23 +27,23 @@
   (testing "Second row is being hidden here."
     (is (=  (table (row (cell "first"))
                    (row (cell "third")))
-            (postprocess (table (row (cell "first"))
-                                (row (cell "second" (->HideTableRowMarker)))
-                                (row (cell "third"))))))))
+            (fix-tables (table (row (cell "first"))
+                               (row (cell "second" (->HideTableRowMarker)))
+                               (row (cell "third"))))))))
 
 (deftest test-column-merging-simple
   (testing "Second column is being hidden here."
     (is (=  (table (row (cell "x1"))
                    (row (cell "d1")))
-            (postprocess (table (row (cell "x1") (cell (->HideTableColumnMarker)))
-                                (row (cell "d1") (cell "d2"))))))))
+            (fix-tables (table (row (cell "x1") (cell (->HideTableColumnMarker)))
+                               (row (cell "d1") (cell "d2"))))))))
 
 (deftest test-column-merging-joined
   (testing "Second column is being hidden here."
     (is (=  (table (row (cell "x1") (cell "x3"))
                    (row (cell "d1") (cell-of-width 1 "d2")))
-            (postprocess (table (row (cell "x1") (cell (->HideTableColumnMarker) "x2") (cell "x3"))
-                                (row (cell "d1") (cell-of-width 2 "d2"))))))))
+            (fix-tables (table (row (cell "x1") (cell (->HideTableColumnMarker) "x2") (cell "x3"))
+                               (row (cell "d1") (cell-of-width 2 "d2"))))))))
 
 (deftest test-column-merging-super-complex
   (testing "Second column is being hidden here."
@@ -54,7 +54,7 @@
           (row (cell "H") (cell-of-width 1 "I3 + J3"))
           (row (cell "H") (cell "J"))
           (row (cell-of-width 2 "F + G + H + I + J")))
-         (postprocess
+         (fix-tables
           (table
            (row (cell-of-width 2 "F1+G1" (->HideTableColumnMarker)) (cell "H1") (cell "I1" (->HideTableColumnMarker)) (cell "J1"))
            (row (cell "F2") (cell "G2") (cell-of-width 2 "H2 + I2") (cell "J2"))
@@ -71,7 +71,7 @@
           (row (cell "H") (cell-of-width 2 "I3 + J3"))
           (row (cell "H") (cell-of-width 2 "J"))
           (row (cell-of-width 3 "F + G + H + I + J")))
-         (postprocess
+         (fix-tables
           (table
            (row (cell-of-width 2 "F1+G1" (->HideTableColumnMarker)) (cell "H1") (cell-of-width 2 "I1" (->HideTableColumnMarker)) (cell-of-width 2 "J1"))
            (row (cell "F2") (cell "G2") (cell-of-width 3 "H2 + I2") (cell-of-width 2 "J2"))
@@ -83,7 +83,7 @@
   (testing "Second column is being hidden here."
     (is (=
          (table (row (cell "X1") (cell "X3")) (row (cell "Y1") (cell "Y3")))
-         (postprocess (table (row (cell "X1") (cell-of-width 2 "X2" (->HideTableColumnMarker)) (cell "X3"))
+         (fix-tables (table (row (cell "X1") (cell-of-width 2 "X2" (->HideTableColumnMarker)) (cell "X3"))
                              (row (cell "Y1") (cell-of-width 2 "Y2") (cell "Y3"))))))))
 
 (deftest test-preprocess-remove-thin-cols
@@ -95,7 +95,7 @@
                      {:tag :gridCol :attrs {:xmlns.http%3A%2F%2Fschemas.openxmlformats.org%2Fwordprocessingml%2F2006%2Fmain/w "3000"}}]}
           (row (cell "X1") (cell "X3"))
           (row (cell "Y1") (cell "Y3")))
-         (postprocess
+         (fix-tables
           (table
            {:tag :tblGrid
             :content [{:tag :gridCol :attrs {:xmlns.http%3A%2F%2Fschemas.openxmlformats.org%2Fwordprocessingml%2F2006%2Fmain/w "2000"}}
@@ -109,7 +109,7 @@
   (testing "We hide second column and expect cells to KEEP size"
     (is (= (table (row (cell-of-width 1 "X1") (cell-of-width 2 "X3"))
                   (row (cell-of-width 1 "Y1") (cell-of-width 2 "Y3")))
-           (postprocess
+           (fix-tables
             (table (row (cell-of-width 1 "X1") (cell-of-width 3 "X2" (->HideTableColumnMarker :cut)) (cell-of-width 2 "X3"))
                    (row (cell-of-width 1 "Y1") (cell-of-width 3 "Y2") (cell-of-width 2 "Y3"))))))))
 
@@ -163,7 +163,7 @@
     (testing "Second column is being hidden here."
       (is (=  (into-hiccup (table (row (cell border-1 "ALMA"))
                                   (row (cell border-2 "NARANCS"))))
-              (into-hiccup (postprocess (table (row (cell "ALMA") (cell border-1 (->HideTableColumnMarker) "KORTE"))
+              (into-hiccup (fix-tables (table (row (cell "ALMA") (cell border-1 (->HideTableColumnMarker) "KORTE"))
                                                (row (cell "NARANCS") (cell border-2 "BARACK"))))))))))
 
 (deftest resize-rational-2


### PR DESCRIPTION
In some cases whitespace characters disappear around substitutions in Microsoft Office Word.

For example consider the following dummy xml content:

```
<a>Amount: {%=x</a><a>%} pieces</a>
```
After substitution it gives:


```
<a>Amount: 23</a><a> pieces</a>
```

The second `<a>` starts with a whitespace character, however, Word does not display that.

This bugfix works the following way:
- In a postprocess steps it looks for `t` elements with text content starting or ending with a whitespace character and adds an `xml:whitespace=preserve` attribute to them.

