### PR TITLE
fix error on double logical negation

### DIFF
--- a/src/stencil/infix.clj
+++ b/src/stencil/infix.clj
@@ -66,6 +66,9 @@
 (defn- precedence [token]
   (get operation-tokens token))
 
+;; operator is left or right associative? returns :left or :right keyword.
+(defn associativity [token] (if (#{:neg :power :not} token) :right :left))
+
 (defn read-string-literal
   "Reads a string literal from a sequence.
    Returns a tuple.
@@ -209,7 +212,9 @@
 
       :otherwise ;; operator
       (let [[popped-ops keep-ops]
-            (split-with #(>= (precedence %) (precedence e0)) opstack)]
+            (split-with #(if (= :left (precedence e0))
+                           (<= (precedence e0) (precedence %))
+                           (< (precedence e0) (precedence %))) opstack)]
         (recur next-expr
                (conj keep-ops e0)
                (into result (remove #{:open :comma} popped-ops))

--- a/test/stencil/infix_test.clj
+++ b/test/stencil/infix_test.clj
@@ -4,7 +4,9 @@
             [stencil.types :refer [hide-table-column-marker?]]
             [clojure.test :refer [deftest testing is are]]))
 
-(defn- run [xs] (infix/eval-rpn {} (infix/parse xs)))
+(defn- run
+  ([xs] (run xs {}))
+  ([xs args] (infix/eval-rpn args (infix/parse xs))))
 
 (deftest tokenize-test
   (testing "simple fn call"
@@ -88,11 +90,31 @@
       (is (false? (run "4 < 2")))
       (is (true? (run "3 <= 3")))
       (is (true? (run "34 >= 2"))))
-
-    (testing "Logikai muveletek"
-      (is (true? (run "3 = 3 && 4 == 4"))))
-
     :ok))
+
+(deftest logical-operators
+  (testing "Mixed"
+    (is (true? (run "3 = 3 && 4 == 4"))))
+
+  (testing "Negation"
+    (is (false? (run "!a" {"a" 1})))
+    (is (true? (run "!a" {"a" false})))
+    (is (true? (run "!a" {})))
+    (is (true? (run "!!a" {"a" nil})))
+    (is (false? (run "!!a" {"a" true}))))
+
+  (testing "Logical AND"
+    (testing "Short form"
+      (is (= 1 (run "a & b" {"a" 1 "b" 1})))
+      (is (nil? (run "a & b" {"a" 1 "b" nil})))
+      (is (nil? (run "a & b" {"b" 2})))
+      (is (nil? (run "a & b" {"a" false}))))
+    (testing "Long form"
+      (is (= 1 (run "a && b" {"a" 1 "b" 1})))
+      (is (nil? (run "a && b" {"a" 1 "b" nil})))
+      (is (nil? (run "a && b" {"b" 2})))
+      (is (nil? (run "a && b" {"a" false})))))
+  :ok)
 
 (deftest operator-precedeces
   (testing "Operator precedencia"

--- a/test/stencil/infix_test.clj
+++ b/test/stencil/infix_test.clj
@@ -100,8 +100,9 @@
     (is (false? (run "!a" {"a" 1})))
     (is (true? (run "!a" {"a" false})))
     (is (true? (run "!a" {})))
-    (is (true? (run "!!a" {"a" nil})))
-    (is (false? (run "!!a" {"a" true}))))
+    (testing "Double negation"
+      (is (false? (run "!!a" {"a" nil})))
+      (is (true? (run "!!a" {"a" true})))))
 
   (testing "Logical AND"
     (testing "Short form"


### PR DESCRIPTION
resolves #7 by introducing operator precedences in the Shinging Yard algorithm in `infix.clj` file.