### PR TITLE
windows support

### DIFF
--- a/java-src/io/github/erdos/stencil/impl/FileHelper.java
+++ b/java-src/io/github/erdos/stencil/impl/FileHelper.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 /**
  * File handling utilities.
@@ -110,19 +111,23 @@ public final class FileHelper {
 
     /**
      * Returns a string representation of path with unix separators ("/") instead of the
-     * system-dependent separators (which can be a backslash on windows.)
+     * system-dependent separators (which is backslash on windows.)
+     *
+     * @param path not null path object
+     * @return string of path with slash separators
+     * @throws IllegalArgumentException if path is null
      */
     public static String toUnixSeparatedString(Path path) {
         if (path == null) {
-            throw new IllegalArgumentException("Path can not be null!");
+            throw new IllegalArgumentException("Path must not be null!");
         } else {
             final String separator = FileSystems.getDefault().getSeparator();
             if (separator.equals("/")) {
                 // on unix systems
                 return path.toString();
             } else {
-                // on windows systems
-                return path.toString().replaceAll(separator, "/");
+                // on windows systems we replace backslash with slashes
+                return path.toString().replaceAll(Pattern.quote(separator), "/");
             }
         }
     }

--- a/java-src/io/github/erdos/stencil/impl/FileHelper.java
+++ b/java-src/io/github/erdos/stencil/impl/FileHelper.java
@@ -2,6 +2,8 @@ package io.github.erdos.stencil.impl;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
 import java.util.UUID;
 
 /**
@@ -102,6 +104,25 @@ public final class FileHelper {
         if (file.isDirectory()) {
             for (File child : file.listFiles()) {
                 forceDeleteOnExit(child);
+            }
+        }
+    }
+
+    /**
+     * Returns a string representation of path with unix separators ("/") instead of the
+     * system-dependent separators (which can be a backslash on windows.)
+     */
+    public static String toUnixSeparatedString(Path path) {
+        if (path == null) {
+            throw new IllegalArgumentException("Path can not be null!");
+        } else {
+            final String separator = FileSystems.getDefault().getSeparator();
+            if (separator.equals("/")) {
+                // on unix systems
+                return path.toString();
+            } else {
+                // on windows systems
+                return path.toString().replaceAll(separator, "/");
             }
         }
     }

--- a/src/stencil/process.clj
+++ b/src/stencil/process.clj
@@ -45,7 +45,7 @@
                                :when (.endsWith (.toLowerCase (str w)) ".xml")]
                            (str (io/file dir w))))
           xml-files (concat (files "word") (files (io/file "ppt" (io/file "slides"))))
-          execs     (zipmap xml-files (map #(->executable (File. zip-dir (str %))) xml-files))]
+          execs     (zipmap xml-files (map #(->executable (io/file zip-dir %)) xml-files))]
       ;; TODO: maybe make it smarter by loading only important xml files
       ;; such as document.xml and footers/headers
       {:zip-dir    zip-dir

--- a/src/stencil/process.clj
+++ b/src/stencil/process.clj
@@ -41,10 +41,10 @@
   (let [zip-dir   (FileHelper/createNonexistentTempFile "stencil-" (str suffix ".zip.contents"))]
     (with-open [zip-stream stream] ;; FIXME: maybe not deleted immediately
       (ZipHelper/unzipStreamIntoDirectory zip-stream zip-dir))
-    (let [files (fn [dir] (for [w (concat (.list (File. zip-dir (str dir))))
-                                :when (.endsWith (str w) ".xml")]
-                            (str dir "/" w)))
-          xml-files (concat (files "word") (files "ppt/slides"))
+    (let [files (fn [dir] (for [w (.list (io/file zip-dir dir))
+                               :when (.endsWith (.toLowerCase (str w)) ".xml")]
+                           (str (io/file dir w))))
+          xml-files (concat (files "word") (files (io/file "ppt" (io/file "slides"))))
           execs     (zipmap xml-files (map #(->executable (File. zip-dir (str %))) xml-files))]
       ;; TODO: maybe make it smarter by loading only important xml files
       ;; such as document.xml and footers/headers

--- a/src/stencil/process.clj
+++ b/src/stencil/process.clj
@@ -78,7 +78,7 @@
   (let [data   (into {} data)
         {:keys [zip-dir exec-files]} template
         source-dir   (io/file zip-dir)
-        pp           (.toPath source-dir)
+        source-dir-path (.toPath source-dir)
         outstream    (new PipedOutputStream)
         input-stream (new PipedInputStream outstream)
         executed-files (into {}
@@ -90,7 +90,7 @@
           (doseq [file  (file-seq source-dir)
                   :when (not      (.isDirectory ^File file))
                   :let  [path     (.toPath ^File file)
-                         rel-path (str (.relativize pp path))
+                         rel-path (FileHelper/toUnixSeparatedString (.relativize source-dir-path path))
                          ze       (new ZipEntry rel-path)]]
             (.putNextEntry zipstream ze)
             (if-let [writer (get executed-files rel-path)]

--- a/src/stencil/process.clj
+++ b/src/stencil/process.clj
@@ -43,7 +43,7 @@
       (ZipHelper/unzipStreamIntoDirectory zip-stream zip-dir))
     (let [files (fn [dir] (for [w (.list (io/file zip-dir dir))
                                :when (.endsWith (.toLowerCase (str w)) ".xml")]
-                           (str (io/file dir w))))
+                           (FileHelper/toUnixSeparatedString (.toPath (io/file dir w)))))
           xml-files (concat (files "word") (files (io/file "ppt" (io/file "slides"))))
           execs     (zipmap xml-files (map #(->executable (io/file zip-dir %)) xml-files))]
       ;; TODO: maybe make it smarter by loading only important xml files


### PR DESCRIPTION
On windows machines the generated docx files contain file paths with backslash (`\`) file separators. This bugfix enforces the use of `/` characters instead. See #20 for details.