### PR TITLE
performance improvements by removing parallelism

### DIFF
--- a/build-native-image.sh
+++ b/build-native-image.sh
@@ -28,6 +28,7 @@ OUTPUT=stencil-native
 native-image \
     -jar $TARGET_JAR \
     -H:ReflectionConfigurationFiles=./reflectconfig \
+    -H:-MultiThreaded \
     -H:IncludeResources='.*.txt$' \
     --report-unsupported-elements-at-runtime \
     $OUTPUT

--- a/java-src/io/github/erdos/stencil/EvaluatedDocument.java
+++ b/java-src/io/github/erdos/stencil/EvaluatedDocument.java
@@ -26,18 +26,6 @@ public interface EvaluatedDocument {
         }
     }
 
-    default void writeToChannel(WritableByteChannel channel) throws IOException {
-        try (OutputStream stream = Channels.newOutputStream(channel)) {
-            writeToStream(stream);
-        }
-    }
-
-    default void writeToChannel(AsynchronousByteChannel channel) throws IOException {
-        try (OutputStream stream = Channels.newOutputStream(channel)) {
-            writeToStream(stream);
-        }
-    }
-
     default void writeToStream(OutputStream outputStream) {
         getWriter().accept(outputStream);
     }

--- a/java-src/io/github/erdos/stencil/EvaluatedDocument.java
+++ b/java-src/io/github/erdos/stencil/EvaluatedDocument.java
@@ -1,9 +1,6 @@
 package io.github.erdos.stencil;
 
 import java.io.*;
-import java.nio.channels.AsynchronousByteChannel;
-import java.nio.channels.Channels;
-import java.nio.channels.WritableByteChannel;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 

--- a/java-src/io/github/erdos/stencil/EvaluatedDocument.java
+++ b/java-src/io/github/erdos/stencil/EvaluatedDocument.java
@@ -1,26 +1,70 @@
 package io.github.erdos.stencil;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
+import java.io.*;
+import java.nio.channels.AsynchronousByteChannel;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Consumer;
 
 /**
  * An evaluated document ready to be converted to the final output format.
  */
+@SuppressWarnings("unused")
 public interface EvaluatedDocument {
 
-    /**
-     * Content of document as input stream.
-     */
-    InputStream getInputStream();
-
     TemplateDocumentFormats getFormat();
+
+    Consumer<OutputStream> getWriter();
 
     /**
      * Writes output of this document to a file
      */
     default void writeToFile(File output) throws IOException {
-        Files.copy(getInputStream(), output.toPath());
+        try (FileOutputStream fos = new FileOutputStream(output)) {
+            writeToStream(fos);
+        }
+    }
+
+    default void writeToChannel(WritableByteChannel channel) throws IOException {
+        try (OutputStream stream = Channels.newOutputStream(channel)) {
+            writeToStream(stream);
+        }
+    }
+
+    default void writeToChannel(AsynchronousByteChannel channel) throws IOException {
+        try (OutputStream stream = Channels.newOutputStream(channel)) {
+            writeToStream(stream);
+        }
+    }
+
+    default void writeToStream(OutputStream outputStream) {
+        getWriter().accept(outputStream);
+    }
+
+    /**
+     * Creates a blocking input stream that can be used to render generated document.
+     *
+     * @param executorService used to stream output.
+     * @return a new input stream that contains the generated document
+     * @throws NullPointerException  if executorService is null
+     * @throws IllegalStateException if executorService would use the current thread
+     */
+    default InputStream toInputStream(ExecutorService executorService) {
+        final PipedOutputStream outputStream = new PipedOutputStream();
+        final PipedInputStream inputStream = new PipedInputStream();
+
+        final long parentId = Thread.currentThread().getId();
+
+        executorService.submit(() -> {
+            final long childId = Thread.currentThread().getId();
+            if (childId == parentId) {
+                throw new IllegalStateException("The supplied executor must submit jobs to new threads!");
+            } else {
+                writeToStream(outputStream);
+            }
+        });
+
+        return inputStream;
     }
 }

--- a/java-src/io/github/erdos/stencil/Main.java
+++ b/java-src/io/github/erdos/stencil/Main.java
@@ -10,8 +10,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
 
-import static io.github.erdos.stencil.impl.ClojureHelper.callShutdownAgents;
-
 public class Main {
 
     public static void main(String... args) throws IOException {
@@ -39,9 +37,6 @@ public class Main {
                 System.out.println("File: " + new File(e.getFile()).getCanonicalPath());
             }
             System.exit(5);
-        } finally {
-            // stop Clojure thread pools
-            callShutdownAgents();
         }
     }
 

--- a/java-src/io/github/erdos/stencil/impl/ClojureHelper.java
+++ b/java-src/io/github/erdos/stencil/impl/ClojureHelper.java
@@ -42,12 +42,5 @@ public class ClojureHelper {
     public static IFn findFunction(String functionName) {
         return RT.var("stencil.process", functionName);
     }
-
-    /**
-     * Shuts down clojure agents. Needed to speed up quitting from Clojure programs.
-     */
-    public static void callShutdownAgents() {
-        RT.var("clojure.core", "shutdown-agents").run();
-    }
 }
 

--- a/java-src/io/github/erdos/stencil/impl/ClojureHelper.java
+++ b/java-src/io/github/erdos/stencil/impl/ClojureHelper.java
@@ -5,6 +5,8 @@ import clojure.lang.Keyword;
 import clojure.lang.RT;
 import clojure.lang.Symbol;
 
+import java.util.Map;
+
 /**
  * Clojure utilities.
  */
@@ -12,9 +14,17 @@ import clojure.lang.Symbol;
 public class ClojureHelper {
 
     enum Keywords {
-        DATA, FORMAT, FUNCTION, FRAGMENTS, STREAM, TEMPLATE, VARIABLES, ZIP_DIR, CONTENT, SOURCE_FOLDER;
+        DATA, FUNCTION, FRAGMENTS, TEMPLATE, VARIABLES, SOURCE_FOLDER, WRITER;
 
         public final Keyword kw = Keyword.intern(name().toLowerCase().replace('_', '-'));
+
+        public final <V> V getOrThrow(Map<?, V> m) {
+            if (!m.containsKey(kw)) {
+                throw new IllegalArgumentException("Map does not contain keyword " + kw);
+            } else {
+                return m.get(kw);
+            }
+        }
     }
 
     // requires stencil.process namespace so stencil is loaded.

--- a/src/stencil/api.clj
+++ b/src/stencil/api.clj
@@ -44,8 +44,8 @@
   - {:fragments {\"fragmentName\" fragment-object}} map of document fragments to embed in template.
   - {:output FNAME} renders output to file FNAME (string or File object). Throws exception
     if file already exists and :overwrite? option is not set.
-  - {:output :input-stream} returns an input stream of the result document.
-  - {:output :reader} returns the input stream reader of the result document."
+  - {:output STREAM} writes output to an OutputStream object.
+  - {:output :input-stream} returns an input stream of the result document."
   [template template-data & {:as opts}]
   (let [template      (prepare template)
         fragments     (into {} (for [[k v] (:fragments opts)] [(name k) (fragment v)]))
@@ -55,8 +55,8 @@
       (#{:stream :input-stream} (:output opts))
       (.getInputStream result)
 
-      (#{:reader} (:output opts))
-      (new InputStreamReader (.getInputStream result))
+      (instance? java.io.OutputStream (:output opts))
+      (.writeToStream result)
 
       (:output opts)
       (let [f (io/file (:output opts))]

--- a/src/stencil/api.clj
+++ b/src/stencil/api.clj
@@ -53,10 +53,10 @@
         result (API/render template fragments template-data)]
     (cond
       (#{:stream :input-stream} (:output opts))
-      (.getInputStream result)
+      (.toInputStream result clojure.lang.Agent/soloExecutor)
 
       (instance? java.io.OutputStream (:output opts))
-      (.writeToStream result)
+      (.writeToStream result (:output opts))
 
       (:output opts)
       (let [f (io/file (:output opts))]

--- a/src/stencil/model.clj
+++ b/src/stencil/model.clj
@@ -284,6 +284,14 @@
                       (resource-copier {:path path :source-file src}))]))))
 
 
+(defn template-model->writers-map
+  [template data function fragments]
+  (assert (map? data))
+  (-> template
+      (eval-template-model data function fragments)
+      (evaled-template-model->writers-map)))
+
+
 (defn- extract-body-parts [xml-tree]
   (assert (:tag xml-tree))
   (doall


### PR DESCRIPTION
this change removes the usage of parallelism by eliminating `future` calls in `process.clj`.

1. This lets us remove multithreading from the compiled `native-image` version of the standalone application reducing executable file size by about _4%_ and runtime by _almost 50%_.

2. Removes the need to call `(shutdown-agents)` after using the library to shut down Clojure's agent thread pools.