### PR TITLE
Feature/fragment names

### DIFF
--- a/java-src/io/github/erdos/stencil/TemplateVariables.java
+++ b/java-src/io/github/erdos/stencil/TemplateVariables.java
@@ -20,11 +20,13 @@ import static java.util.stream.Collectors.toList;
  */
 public final class TemplateVariables {
 
+    private final Set<String> fragmentNames;
     private final Set<String> variables;
     private final Node root;
 
-    private TemplateVariables(Set<String> variables) {
+    private TemplateVariables(Set<String> variables, Set<String> fragmentNames) {
         this.variables = unmodifiableSet(variables);
+        this.fragmentNames = unmodifiableSet(fragmentNames);
 
         Node r = LEAF;
         for (String x : variables) {
@@ -124,8 +126,12 @@ public final class TemplateVariables {
         return variables;
     }
 
+    public Set<String> getAllFragmentNames() {
+        return fragmentNames;
+    }
+
     /**
-     * Throws IllegalArgumentException exception when template data.
+     * Throws IllegalArgumentException exception when template data is missing values for schema.
      * <p>
      * Throws when referred keys are missing from data.
      *

--- a/java-src/io/github/erdos/stencil/TemplateVariables.java
+++ b/java-src/io/github/erdos/stencil/TemplateVariables.java
@@ -114,8 +114,8 @@ public final class TemplateVariables {
         }
     }
 
-    public static TemplateVariables fromPaths(Collection<String> allVariablePaths) {
-        return new TemplateVariables(new HashSet<>(allVariablePaths));
+    public static TemplateVariables fromPaths(Collection<String> allVariablePaths, Collection<String> allFragmentNames) {
+        return new TemplateVariables(new HashSet<>(allVariablePaths), new HashSet<>(allFragmentNames));
     }
 
     /**

--- a/java-src/io/github/erdos/stencil/impl/NativeTemplateFactory.java
+++ b/java-src/io/github/erdos/stencil/impl/NativeTemplateFactory.java
@@ -78,6 +78,13 @@ public final class NativeTemplateFactory implements TemplateFactory {
     }
 
     @SuppressWarnings("unchecked")
+    private Set fragmentNames(Map prepared) {
+        return prepared.containsKey(ClojureHelper.Keywords.VARIABLES)
+                ? unmodifiableSet(new HashSet<Set>((Collection) prepared.get(ClojureHelper.Keywords.FRAGMENTS)))
+                : emptySet();
+    }
+
+    @SuppressWarnings("unchecked")
     private PreparedTemplate prepareTemplateImpl(TemplateDocumentFormats templateDocFormat, InputStream input, File originalFile) {
         final IFn prepareFunction = ClojureHelper.findFunction("prepare-template");
 
@@ -92,7 +99,7 @@ public final class NativeTemplateFactory implements TemplateFactory {
             throw ParsingException.wrapping("Could not parse template file!", e);
         }
 
-        final TemplateVariables vars = TemplateVariables.fromPaths(variableNames(prepared));
+        final TemplateVariables vars = TemplateVariables.fromPaths(variableNames(prepared), fragmentNames(prepared));
 
         final File zipDirResource = (File) prepared.get(ClojureHelper.Keywords.SOURCE_FOLDER.kw);
         if (zipDirResource != null) {

--- a/java-src/io/github/erdos/stencil/impl/NativeTemplateFactory.java
+++ b/java-src/io/github/erdos/stencil/impl/NativeTemplateFactory.java
@@ -72,15 +72,15 @@ public final class NativeTemplateFactory implements TemplateFactory {
     @SuppressWarnings("unchecked")
     private Set variableNames(Map prepared) {
         // TODO: ez mindig null lesz ugyhogy csinaljunk vele valamit!!!!!
-        return prepared.containsKey(ClojureHelper.Keywords.VARIABLES)
-                ? unmodifiableSet(new HashSet<Set>((Collection) prepared.get(ClojureHelper.Keywords.VARIABLES)))
+        return prepared.containsKey(ClojureHelper.Keywords.VARIABLES.kw)
+                ? unmodifiableSet(new HashSet<Set>((Collection) prepared.get(ClojureHelper.Keywords.VARIABLES.kw)))
                 : emptySet();
     }
 
     @SuppressWarnings("unchecked")
     private Set fragmentNames(Map prepared) {
-        return prepared.containsKey(ClojureHelper.Keywords.VARIABLES)
-                ? unmodifiableSet(new HashSet<Set>((Collection) prepared.get(ClojureHelper.Keywords.FRAGMENTS)))
+        return prepared.containsKey(ClojureHelper.Keywords.FRAGMENTS.kw)
+                ? unmodifiableSet(new HashSet<Set>((Collection) prepared.get(ClojureHelper.Keywords.FRAGMENTS.kw)))
                 : emptySet();
     }
 

--- a/java-src/io/github/erdos/stencil/impl/NativeTemplateFactory.java
+++ b/java-src/io/github/erdos/stencil/impl/NativeTemplateFactory.java
@@ -71,7 +71,6 @@ public final class NativeTemplateFactory implements TemplateFactory {
      */
     @SuppressWarnings("unchecked")
     private Set variableNames(Map prepared) {
-        // TODO: ez mindig null lesz ugyhogy csinaljunk vele valamit!!!!!
         return prepared.containsKey(ClojureHelper.Keywords.VARIABLES.kw)
                 ? unmodifiableSet(new HashSet<Set>((Collection) prepared.get(ClojureHelper.Keywords.VARIABLES.kw)))
                 : emptySet();

--- a/java-test/io/github/erdos/stencil/TemplateVariablesTest.java
+++ b/java-test/io/github/erdos/stencil/TemplateVariablesTest.java
@@ -20,7 +20,7 @@ public class TemplateVariablesTest {
         final Set<String> schema = set("a.x.p", "a.x.q");
         Map<String, Object> data = map("a", map("x", map("p", null, "q", 23)));
 
-        fromPaths(schema).throwWhenInvalid(fromMap(data));
+        fromPaths(schema, emptySet()).throwWhenInvalid(fromMap(data));
     }
 
 
@@ -30,12 +30,12 @@ public class TemplateVariablesTest {
 
         // valid
         final Map<String, Object> data = singletonMap("x", asList(1, 2, 3));
-        fromPaths(schema).throwWhenInvalid(fromMap(data));
+        fromPaths(schema, emptySet()).throwWhenInvalid(fromMap(data));
 
         try {
             // invalid
             final TemplateData data2 = fromMap(singletonMap("a", singletonMap("x", asList(1, 2, 3))));
-            fromPaths(schema).throwWhenInvalid(data2);
+            fromPaths(schema, emptySet()).throwWhenInvalid(data2);
             fail("Should have thrown!");
         } catch (IllegalArgumentException ignored) {
         }
@@ -47,11 +47,11 @@ public class TemplateVariablesTest {
 
         // valid
         final Map<String, Object> data = singletonMap("a", singletonMap("x", singletonList(singletonList(singletonMap("p", 1)))));
-        fromPaths(schema).throwWhenInvalid(fromMap(data));
+        fromPaths(schema, emptySet()).throwWhenInvalid(fromMap(data));
 
         try {
             // invalid
-            fromPaths(schema).throwWhenInvalid(fromMap(singletonMap("a", singletonMap("x", asList(1, 2, 3)))));
+            fromPaths(schema, emptySet()).throwWhenInvalid(fromMap(singletonMap("a", singletonMap("x", asList(1, 2, 3)))));
             fail("Should have thrown!");
         } catch (IllegalArgumentException ignored) {
         }
@@ -64,7 +64,7 @@ public class TemplateVariablesTest {
         try {
             // invalid
             final Map<String, Object> data = singletonMap("a", 3);
-            fromPaths(schema).throwWhenInvalid(fromMap(data));
+            fromPaths(schema, emptySet()).throwWhenInvalid(fromMap(data));
             fail("Should have thrown!");
         } catch (IllegalArgumentException ignored) {
         }

--- a/src/stencil/cleanup.clj
+++ b/src/stencil/cleanup.clj
@@ -208,12 +208,18 @@
                        []))]
     (distinct (collect {} control-ast))))
 
-; (find-variables [])
+(defn- find-fragments [control-ast]
+  ;; returns a set of fragment names use in this document
+  (set (for [item (tree-seq map? (comp flatten :blocks) {:blocks [control-ast]})
+             :when (map? item)
+             :when (= :cmd/include (:cmd item))]
+         (:name item))))
 
 (defn process [raw-token-seq]
   (let [ast (tokens->ast raw-token-seq)
         executable (control-ast-normalize (annotate-environments ast))]
     {:variables  (find-variables ast)
+     :fragments  (find-fragments ast)
      :dynamic?   (boolean (some :cmd executable))
      :executable executable}))
 

--- a/src/stencil/model.clj
+++ b/src/stencil/model.clj
@@ -100,7 +100,7 @@
   (with-open [stream (io/input-stream xml-streamable)]
     (-> (tokenizer/parse-to-tokens-seq stream)
         (cleanup/process)
-        (select-keys [:variables :dynamic? :executable]))))
+        (select-keys [:variables :dynamic? :executable :fragments]))))
 
 
 (defn load-template-model [^File dir]

--- a/src/stencil/process.clj
+++ b/src/stencil/process.clj
@@ -18,6 +18,14 @@
              (into (for [x (:headers+footers (:main model))
                          f (:fragments (:executable x))] f)))))
 
+(defn- merge-variable-names [model]
+  (assoc model
+         :variables
+         (-> #{}
+             (into (-> model :main :executable :variables))
+             (into (for [x (:headers+footers (:main model))
+                         v (:variables (:executable x))] v)))))
+
 (defn prepare-template [^InputStream stream]
   (assert (instance? InputStream stream))
   (let [zip-dir   (FileHelper/createNonexistentTempFile "stencil-" ".zip.contents")]
@@ -25,7 +33,8 @@
       (ZipHelper/unzipStreamIntoDirectory zip-stream zip-dir))
     (-> zip-dir
         model/load-template-model
-        merge-fragment-names)))
+        merge-fragment-names
+        merge-variable-names)))
 
 (defn prepare-fragment [input]
   (assert (some? input))

--- a/test/stencil/api_test.clj
+++ b/test/stencil/api_test.clj
@@ -118,13 +118,14 @@
                      {"customerName" "John Doe" "x" "XXX" "y" "yyyy"}))
 
 (deftest test-prepare-fragment-names
-  (let [template (prepare "test-resources/multipart/main.docx")]
-    (is (= #{"header" "footer" "body"}
-           (-> template .getVariables .getAllFragmentNames)))
-    (cleanup! template)))
+  (with-open [template (prepare "test-resources/multipart/main.docx")]
+    (is (= #{"header" "footer" "body"} (-> template .getVariables .getAllFragmentNames)))))
+
+(deftest test-prepare-variable-names
+  (with-open [template (prepare "test-resources/multipart/header.docx")]
+    (is (= #{"name"} (-> template .getVariables .getAllVariables)))))
 
 (comment
-
 
   (let [template (prepare "test-resources/multipart/main.docx")
         body     (fragment "test-resources/multipart/body.docx")

--- a/test/stencil/api_test.clj
+++ b/test/stencil/api_test.clj
@@ -117,6 +117,12 @@
   (render-template-2 "/tmp/output-7.pptx"
                      {"customerName" "John Doe" "x" "XXX" "y" "yyyy"}))
 
+(deftest test-prepare-fragment-names
+  (let [template (prepare "test-resources/multipart/main.docx")]
+    (is (= #{"header" "footer" "body"}
+           (-> template .getVariables .getAllFragmentNames)))
+    (cleanup! template)))
+
 (comment
 
 

--- a/test/stencil/process_test.clj
+++ b/test/stencil/process_test.clj
@@ -31,5 +31,6 @@
                          {:blocks [], :cmd :cmd/include, :name "elefant"}
                          {:close :b}
                          {:close :a}],
+            :fragments #{"elefant"}
             :variables ()}
            (test-prepare "<a><b>{%include \"elefant\"%}</b></a>")))))


### PR DESCRIPTION
add a `getAllFragmentNames` method to the `TemplateVariables` class to query all referenced fragment names. Solves #26 