### PR TITLE
fix: propagate exception on EvaluatedDocument.toInputStream

### DIFF
--- a/java-src/io/github/erdos/stencil/EvaluatedDocument.java
+++ b/java-src/io/github/erdos/stencil/EvaluatedDocument.java
@@ -64,7 +64,7 @@ public interface EvaluatedDocument {
                     inputStreamErrors.fail(e);
                     throw e;
                 } finally {
-                    inputStreamErrors.countDown();
+                    inputStreamErrors.finish();
                 }
             }
         });

--- a/java-src/io/github/erdos/stencil/impl/InputStreamExceptionPropagation.java
+++ b/java-src/io/github/erdos/stencil/impl/InputStreamExceptionPropagation.java
@@ -1,0 +1,44 @@
+package io.github.erdos.stencil.impl;
+
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Objects.requireNonNull;
+
+public final class InputStreamExceptionPropagation extends FilterInputStream {
+    private final AtomicReference<Throwable> exception = new AtomicReference<>(null);
+    private final CountDownLatch complete = new CountDownLatch(1);
+
+    public InputStreamExceptionPropagation(final InputStream stream) {
+        super(stream);
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            complete.await();
+            final Throwable e = exception.get();
+            if (e instanceof IOException) {
+                throw (IOException) e;
+            } else if (e != null) {
+                throw new IOException("Exception while writing", e);
+            }
+        } catch (final InterruptedException e) {
+            throw new IOException("Interrupted while waiting for synchronised closure");
+        } finally {
+            in.close();
+        }
+    }
+
+    public void fail(final Throwable e) {
+        exception.set(requireNonNull(e));
+    }
+
+    public void countDown() {
+        complete.countDown();
+    }
+}

--- a/java-src/io/github/erdos/stencil/impl/InputStreamExceptionPropagation.java
+++ b/java-src/io/github/erdos/stencil/impl/InputStreamExceptionPropagation.java
@@ -27,8 +27,8 @@ public final class InputStreamExceptionPropagation extends FilterInputStream {
             } else if (e != null) {
                 throw new IOException("Exception while writing", e);
             }
-        } catch (final InterruptedException e) {
-            throw new IOException("Interrupted while waiting for synchronised closure");
+        } catch (InterruptedException e) {
+            throw new IOException("Interrupted!", e);
         } finally {
             in.close();
         }
@@ -38,7 +38,7 @@ public final class InputStreamExceptionPropagation extends FilterInputStream {
         exception.set(requireNonNull(e));
     }
 
-    public void countDown() {
+    public void finish() {
         complete.countDown();
     }
 }


### PR DESCRIPTION
Fixes https://github.com/erdos/stencil/issues/34 by wrapping the produced `InputStream` in a proxy that throws the wrapped exception on the `.close()` method call.