### PR TITLE
Pin clojure build image to an older tag

### DIFF
--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -1,4 +1,4 @@
-FROM clojure AS build-env
+FROM clojure:lein-2.8.1 AS build-env
 WORKDIR /usr/src/myapp
 
 COPY project.clj /usr/src/myapp/

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -8,7 +8,7 @@ COPY . /usr/src/myapp
 
 RUN mv "$(lein uberjar | sed -n 's/^Created \(.*standalone\.jar\)/\1/p')" myapp-standalone.jar
 
-FROM openjdk:8-jre-alpine
+FROM openjdk:8-jre-buster
 
 ENV STENCIL_HTTP_PORT 8080
 ENV STENCIL_TEMPLATE_DIR /templates


### PR DESCRIPTION
My name is Eugene, I're exploring the possibility of using stencil in Contractbook, the company I work for. When trying to build an image, I've stumbled upon an issue.

With clojure base image tagged as "latest", it is not possible to build that image. The following error is returned:

```
Step 6/15 : RUN mv "$(lein uberjar | sed -n 's/^Created \(.*standalone\.jar\)/\1/p')" myapp-standalone.jar
 ---> Running in 288116953c6e
Compiling stencil.service.core
java.lang.ClassNotFoundException: javax.xml.bind.DatatypeConverter, compiling:(server.clj:1:1)
Exception in thread "main" java.lang.ClassNotFoundException: javax.xml.bind.DatatypeConverter, compiling:(server.clj:1:1)
        at clojure.lang.Compiler$InvokeExpr.eval(Compiler.java:3700)
  ...
Caused by: java.lang.ClassNotFoundException: javax.xml.bind.DatatypeConverter
        at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:471)
        at clojure.lang.DynamicClassLoader.findClass(DynamicClassLoader.java:69)
  ...
```

According to https://stackoverflow.com/a/43574427/80851, a specific set of modules is missing from recent versions of Java.

This commit pins clojure image to an older tag, e.g. clojure:lein-2.8.1 to fix building the image.

There only reason I choose `clojure:lein-2.8.1` was to pick an old one enough to build the image. There's likely a more appropriate version to choose. Separately, I believe a better solution would be to update the code / dependencies to not rely on deprecated Java modules.

I am do not program in Java, so I went with smallest possible fix that unblocks me from building the images.