### PR TITLE
release version 0.3.13, fix error on closed input stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ The project has a simple [service implementation](https://github.com/erdos/stenc
 
 ## Version
 
-**Latest stable** version is `0.3.12`
+**Latest stable** version is `0.3.13`
 
-**Latest snapshot** version is `0.3.13-SNAPSHOT`
+**Latest snapshot** version is `0.3.14-SNAPSHOT`
 
 If you are using Maven, add the followings to your `pom.xml`:
 
@@ -57,7 +57,7 @@ The dependency:
 <dependency>
   <groupId>io.github.erdos</groupId>
   <artifactId>stencil-core</artifactId>
-  <version>0.3.12</version>
+  <version>0.3.13</version>
 </dependency>
 ```
 
@@ -72,7 +72,7 @@ And the [Clojars](https://clojars.org) repository:
 
 Alternatively, if you are using Leiningen, add the following to
 the `:dependencies` section of your `project.clj`
-file: `[io.github.erdos/stencil-core "0.3.12"]`
+file: `[io.github.erdos/stencil-core "0.3.13"]`
 
 Previous versions are available on the [Stencil Clojars](https://clojars.org/io.github.erdos/stencil-core) page.
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.erdos/stencil-core "0.3.12"
+(defproject io.github.erdos/stencil-core "0.3.13"
   :url "https://github.com/erdos/stencil"
   :description       "Templating engine for office documents."
   :license {:name "Eclipse Public License - v 2.0"

--- a/service/project.clj
+++ b/service/project.clj
@@ -1,10 +1,10 @@
-(defproject io.github.erdos/stencil-service "0.3.12"
+(defproject io.github.erdos/stencil-service "0.3.13"
   :description "Web service for the Stencil templating engine"
   :url "https://github.com/erdos/stencil"
   :license {:name "Eclipse Public License - v 2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.10.2-alpha2"]
-                 [io.github.erdos/stencil-core "0.3.12"]
+                 [io.github.erdos/stencil-core "0.3.13"]
                  [http-kit "2.5.0"]
                  [org.clojure/tools.logging "1.1.0"]
                  [ring/ring-json "0.4.0"]]

--- a/src/stencil/model.clj
+++ b/src/stencil/model.clj
@@ -45,12 +45,10 @@
 (defn- parse-content-types [^File cts]
   (assert (.exists cts))
   (assert (.isFile cts))
-  (let [parsed (with-open [r (io/input-stream cts)] (xml/parse r))]
-    {:source-file cts
-     ::path       (.getName cts)}))
+  {:source-file cts
+   ::path       (.getName cts)})
 
 
-;; TODO: options-map
 (defn ->exec [xml-streamable]
   (with-open [stream (io/input-stream xml-streamable)]
     (-> (merger/parse-to-tokens-seq stream)
@@ -124,8 +122,8 @@
     (eval-model-part-exec (:executable part) data functions)
     {:writer (resource-copier part)
      :xml-delay (delay
-                 (with-open [reader (io/input-stream (:source-file part))]
-                   (update (xml/parse reader) :content doall)))}))
+                  (with-open [reader (io/input-stream (:source-file part))]
+                    (unlazy-tree (xml/parse reader))))}))
 
 
 (defn- eval-template-model [template-model data functions fragments]

--- a/src/stencil/model/numbering.clj
+++ b/src/stencil/model/numbering.clj
@@ -57,14 +57,10 @@
      :start    (->int (node-attr "start"))}))
 
 
-(defn prepare-numbering-xml [xml-tree] xml-tree)
-
-
 (defn- parse [numbering-file]
   (assert numbering-file)
   (with-open [r (io/input-stream (io/file numbering-file))]
-    (let [tree (xml/parse r)]
-      (prepare-numbering-xml tree))))
+    (unlazy-tree (xml/parse r))))
 
 
 (defn main-numbering [dir main-document main-document-rels]

--- a/src/stencil/model/numbering.clj
+++ b/src/stencil/model/numbering.clj
@@ -57,10 +57,14 @@
      :start    (->int (node-attr "start"))}))
 
 
+(defn prepare-numbering-xml [xml-tree]
+  (unlazy-tree xml-tree))
+
+
 (defn- parse [numbering-file]
   (assert numbering-file)
   (with-open [r (io/input-stream (io/file numbering-file))]
-    (unlazy-tree (xml/parse r))))
+    (prepare-numbering-xml (xml/parse r))))
 
 
 (defn main-numbering [dir main-document main-document-rels]

--- a/src/stencil/model/numbering.clj
+++ b/src/stencil/model/numbering.clj
@@ -64,7 +64,8 @@
 (defn- parse [numbering-file]
   (assert numbering-file)
   (with-open [r (io/input-stream (io/file numbering-file))]
-    (prepare-numbering-xml (xml/parse r))))
+    (let [tree (xml/parse r)]
+      (prepare-numbering-xml tree))))
 
 
 (defn main-numbering [dir main-document main-document-rels]

--- a/src/stencil/util.clj
+++ b/src/stencil/util.clj
@@ -108,6 +108,11 @@
   (assert (fn? edit-fn))
   (dfs-walk-xml-node xml-tree predicate #(clojure.zip/edit % edit-fn)))
 
+(defn unlazy-tree [xml-tree]
+  (assert (map? xml-tree))
+  (doto xml-tree
+    (->> (tree-seq map? :content) dorun)))
+
 (defmacro when-pred [pred body]
   `(let [b# ~body]
      (when (~pred b#) b#)))

--- a/src/stencil/util.clj
+++ b/src/stencil/util.clj
@@ -111,7 +111,7 @@
 (defn unlazy-tree [xml-tree]
   (assert (map? xml-tree))
   (doto xml-tree
-    (->> (tree-seq map? :content) dorun)))
+    (-> :content dorun)))
 
 (defmacro when-pred [pred body]
   `(let [b# ~body]


### PR DESCRIPTION
Processing templates may throw exception when lazy xml tree is not yet evaluated but input stream has already been closed.