### PR TITLE
feat: map function

### DIFF
--- a/src/stencil/functions.clj
+++ b/src/stencil/functions.clj
@@ -37,3 +37,13 @@
     (->HideTableColumnMarker)))
 
 (defmethod call-fn "hideRow" [_] (->HideTableRowMarker))
+
+(defn- lookup [column data]
+  (second (or (find data column)
+              (find data (keyword column)))))
+
+(defmethod call-fn "map" [_ ^String column data]
+  (reduce (fn [elems p]
+            (keep (partial lookup p) elems))
+          data
+          (.split column "\\.")))

--- a/test/stencil/infix_test.clj
+++ b/test/stencil/infix_test.clj
@@ -209,6 +209,24 @@
   (is (= nil (run "coalesce(\"\", \"\")")))
   (is (= "a" (run "coalesce(\"\", \"\", \"a\", \"b\")"))))
 
+(deftest map-function
+  (testing "Works for both keyword an string keys"
+    (is (= [1 2 3]
+           (run "map(\"x\", vals)"
+             {"vals" [{"x" 1}
+                      {"x" 2}
+                      {"y" -1}
+                      {:x 3}]}))))
+  (testing "Calling in nil results in empty sequence"
+    (is (= []
+           (run "map(\"x\", vals)" {"vals" nil}))))
+  (testing "map with sum"
+    (is (= 6
+           (run "sum(map(\"x\", vals))"
+                {"vals" [{"x" 1} {"x" 2} {"x" 3}]})))))
+
+
+
 (deftest test-colhide-expr
   (is (hide-table-column-marker? (run "hideColumn()"))))
 


### PR DESCRIPTION
Add a `map()` function that can be used to map values from array of objects.

Example use cases:
- `{%=sum(map("price", items))%}`: to sum the price of items in a list.
- `{%=join(map("name", items)", ")%}`: to join the names of items in a list.

Solves #43 