### PR TITLE
feat: version 0.3.17 - add decimal and integer functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ The project has a simple [service implementation](https://github.com/erdos/stenc
 
 ## Version
 
-**Latest stable** version is `0.3.16`
+**Latest stable** version is `0.3.17`
 
-**Latest snapshot** version is `0.3.17-SNAPSHOT`
+**Latest snapshot** version is `0.3.18-SNAPSHOT`
 
 If you are using Maven, add the followings to your `pom.xml`:
 
@@ -58,7 +58,7 @@ The dependency:
 <dependency>
   <groupId>io.github.erdos</groupId>
   <artifactId>stencil-core</artifactId>
-  <version>0.3.16</version>
+  <version>0.3.17</version>
 </dependency>
 ```
 
@@ -73,7 +73,7 @@ And the [Clojars](https://clojars.org) repository:
 
 Alternatively, if you are using Leiningen, add the following to
 the `:dependencies` section of your `project.clj`
-file: `[io.github.erdos/stencil-core "0.3.16"]`
+file: `[io.github.erdos/stencil-core "0.3.17"]`
 
 Previous versions are available on the [Stencil Clojars](https://clojars.org/io.github.erdos/stencil-core) page.
 

--- a/docs/Functions.md
+++ b/docs/Functions.md
@@ -9,12 +9,14 @@ This is a short description of the functions implemented in Stencil:
 - [coalesce](#coalesce)
 - `currency`
 - [date](#date)
+- [decimal](#decimal)
 - [empty](#empty)
 - [floor](#floor)
 - [format](#format)
 - `hideColumn`
 - `hideRow`
 - [html](#html)
+- [integer](#integer)
 - [join](#join)
 - [length](#length)
 - [lowercase](#lowercase)
@@ -41,6 +43,10 @@ Accepts any number of arguments, returns the first not-empty value.
 - to insert the first filled name value: <code>{<i>%=coalesce(partnerFullName, partnerShortName, partnerName)%</i>}</code>
 - to insert the price of an item or default to zero: <code>{<i>%=coalesce(x.price, x.premium, 0)%</i>}</code>
 
+### Decimal
+
+Converts parameter to decimal number. Returns `null` for missing value.
+
 ### Empty
 
 Decides if a parameter is empty or missing. Useful in conditional statements.
@@ -55,6 +61,10 @@ The `empty()` function is useful when we want to either enumerate the contents
 of an array or hide the whole paragraph when the array is empty.
 
 <img src="screenshot-function-empty-before.png"/>
+
+### Integer
+
+Converts parameter to integer number. Returns `null` for missing value.
 
 ### Map
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.erdos/stencil-core "0.3.17-SNAPSHOT"
+(defproject io.github.erdos/stencil-core "0.3.17"
   :url "https://github.com/erdos/stencil"
   :description       "Templating engine for office documents."
   :license {:name "Eclipse Public License - v 2.0"

--- a/service/project.clj
+++ b/service/project.clj
@@ -1,10 +1,10 @@
-(defproject io.github.erdos/stencil-service "0.3.17-SNAPSHOT"
+(defproject io.github.erdos/stencil-service "0.3.17"
   :description "Web service for the Stencil templating engine"
   :url "https://github.com/erdos/stencil"
   :license {:name "Eclipse Public License - v 2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.10.2-alpha2"]
-                 [io.github.erdos/stencil-core "0.3.17-SNAPSHOT"]
+                 [io.github.erdos/stencil-core "0.3.17"]
                  [http-kit "2.5.0"]
                  [org.clojure/tools.logging "1.1.0"]
                  [ring/ring-json "0.4.0"]]

--- a/src/stencil/functions.clj
+++ b/src/stencil/functions.clj
@@ -16,6 +16,9 @@
   ([_ x y] (range x y))
   ([_ x y z] (range x y z)))
 
+(defmethod call-fn "integer" [_ n] (some-> n biginteger))
+(defmethod call-fn "decimal" [_ f] (some-> f bigdec))
+
 ;; finds first nonempy argument
 (defmethod call-fn "coalesce" [_ & args-seq]
   (find-first (some-fn number? true? false? not-empty) args-seq))

--- a/test/stencil/functions_test.clj
+++ b/test/stencil/functions_test.clj
@@ -4,6 +4,17 @@
             [clojure.test :refer [deftest testing is are]]))
 
 
+(deftest test-numerics
+  (testing "decimal"
+    (is (= (bigdec 0.23)) (call-fn "decimal" 0.23))
+    (is (= nil (call-fn "decimal" nil))))
+  (testing "integer"
+    (is (= (biginteger 10)) (call-fn "integer" 10))
+    (is (= nil (call-fn "integer" nil)))
+    (is (= (biginteger 10) (call-fn "integer" (bigdec 10.2))))
+    (is (= (biginteger 10) (call-fn "integer" (double 10))))))
+
+
 (deftest test-map
   (testing "Empty input"
     (is (= [] (call-fn "map" "x" [])))


### PR DESCRIPTION
Adds `decimal()` and `integer()` functions that can be used to get consistent results with `format()` function.

Relates to https://github.com/erdos/stencil/issues/71