### PR TITLE
feat: formatWithLocale function

### DIFF
--- a/docs/Functions.md
+++ b/docs/Functions.md
@@ -13,6 +13,7 @@ This is a short description of the functions implemented in Stencil:
 - [empty](#empty)
 - [floor](#floor)
 - [format](#format)
+- [formatWithLocale](#formatWithLocale)
 - `hideColumn`
 - `hideRow`
 - [html](#html)
@@ -145,6 +146,10 @@ You can embed custom xml fragments in the document with the `xml()` function. Th
 ### Format
 
 Calls [String.format](https://docs.oracle.com/javase/7/docs/api/java/util/Formatter.html) function.
+
+### FormatWithLocale
+
+Like `format` but first parameter is an IETF Language Tag. For example: `formatWithLocale("hu", "%,.2f", number)`
 
 **Example:**
 

--- a/test/stencil/functions_test.clj
+++ b/test/stencil/functions_test.clj
@@ -17,6 +17,8 @@
 (deftest test-format
   (is (= "hello 42" (call-fn "format" "hello %d" 42)))
   (is (= "hello 42" (call-fn "format" "hello %d" 42.0)))
+  (testing "With custom locale"
+    (is (= "1 000 000,00" (call-fn "formatWithLocale" "hu" "%,.2f" (int 1000000)))))
   (testing "Integer formatting"
     (is (= "1,000,000.00" (call-fn "format" "%,.2f" (int 1000000))))
     (is (= "Hello null" (call-fn "format" "Hello %d" nil))))


### PR DESCRIPTION
See https://github.com/erdos/stencil/issues/76

Adds `formatWithLocale()` function that is similar to `format()` but first argument is IETF Language Tag.

