### PR TITLE
Fix link reference to the formatWithLocale function

### DIFF
--- a/docs/Functions.md
+++ b/docs/Functions.md
@@ -13,7 +13,7 @@ This is a short description of the functions implemented in Stencil:
 - [empty](#empty)
 - [floor](#floor)
 - [format](#format)
-- [formatWithLocale](#formatWithLocale)
+- [formatWithLocale](#formatwithlocale)
 - `hideColumn`
 - `hideRow`
 - [html](#html)


### PR DESCRIPTION
Markdown to HTML convertion tool generates header ids in lowercase