### PR TITLE
feat: localize date function

### DIFF
--- a/docs/Functions.md
+++ b/docs/Functions.md
@@ -101,10 +101,16 @@ Joins a list of items with an optional separator.
 
 Formats a date value according to a given [format string](https://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html).
 
-Arguments:
+When called  with two arguments:
 
 1. First argument is a format string.
 2. Second argument is a string containing a date value.
+
+With three arguments:
+
+1. First argument is an IETF Language Tag string.
+2. First argument is a format string.
+3. Second argument is a string containing a date value.
 
 **Example:**
 

--- a/docs/Functions.md
+++ b/docs/Functions.md
@@ -114,7 +114,8 @@ With three arguments:
 
 **Example:**
 
-This example formats the value of `partner.birthDate` as a date string: <code>{<i>%=date("yyyy-MM-dd", partner.birthDate) %</i>}</code>
+1. This example formats the value of `partner.birthDate` as a date string: <code>{<i>%=date("yyyy-MM-dd", partner.birthDate) %</i>}</code>
+2. With locale: `date("hu", "YYYY MMMM d", "2021-05-20")` evalues to `"2021 május 20"`.
 
 Also, try these formats strings:
 

--- a/java-src/io/github/erdos/stencil/functions/DateFunctions.java
+++ b/java-src/io/github/erdos/stencil/functions/DateFunctions.java
@@ -10,12 +10,14 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 import static java.util.Arrays.asList;
+import static java.util.Locale.forLanguageTag;
+import static java.util.Locale.getDefault;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
-
 /**
  * Date handling functions
  */
@@ -32,27 +34,41 @@ public enum DateFunctions implements Function {
     DATE {
         @Override
         public Object call(Object... arguments) throws IllegalArgumentException {
-            if (arguments.length != 2)
-                throw new IllegalArgumentException("date() function expects exactly 2 arguments!");
+            if (arguments.length != 2 && arguments.length != 3)
+                throw new IllegalArgumentException("date() function expects exactly 2 or 3 arguments!");
             if (arguments[0] == null || arguments[1] == null || arguments[1].toString().isEmpty())
                 return null;
 
-            final String pattern = arguments[0].toString();
-            final Object datum = arguments[1];
+            final Locale locale;
+            final String pattern;
+            final Object datum;
+
+            if (arguments.length == 2) {
+                locale = getDefault();
+                pattern = arguments[0].toString();
+                datum = arguments[1];
+            } else {
+                if (arguments[2] == null || arguments[2].toString().isEmpty()) {
+                    return null;
+                }
+                locale = forLanguageTag(arguments[0].toString());
+                pattern = arguments[1].toString();
+                datum = arguments[2];
+            }
 
             final Optional<LocalDate> d2 = DateFunctions.maybeLocalDate(datum);
             if (d2.isPresent()) {
-                return d2.get().format(DateTimeFormatter.ofPattern(pattern));
+                return d2.get().format(DateTimeFormatter.ofPattern(pattern, locale));
             }
 
             final Optional<LocalDateTime> d3 = DateFunctions.maybeLocalDateTime(datum);
             if (d3.isPresent()) {
-                return d3.get().format(DateTimeFormatter.ofPattern(pattern));
+                return d3.get().format(DateTimeFormatter.ofPattern(pattern, locale));
             }
 
             final Optional<Date> d1 = DateFunctions.maybeDate(datum);
             if (d1.isPresent()) {
-                return new SimpleDateFormat(pattern).format(d1.get());
+                return new SimpleDateFormat(pattern, locale).format(d1.get());
             }
 
             throw new IllegalArgumentException("Could not parse date object " + datum.toString());

--- a/java-src/io/github/erdos/stencil/functions/DateFunctions.java
+++ b/java-src/io/github/erdos/stencil/functions/DateFunctions.java
@@ -18,6 +18,7 @@ import static java.util.Locale.forLanguageTag;
 import static java.util.Locale.getDefault;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
+
 /**
  * Date handling functions
  */

--- a/test/stencil/functions_test.clj
+++ b/test/stencil/functions_test.clj
@@ -36,12 +36,17 @@
     (is (thrown? ExceptionInfo (call-fn "format" nil 2)))))
 
 
-(defmethod call-fn "date" [_ & args]
-  (.call io.github.erdos.stencil.functions.DateFunctions/DATE  (to-array args)))
-
 (deftest test-date
-  (is (= "2021/05/20" (call-fn "date" "YYYY/MM/d", "2021-05-20")))
-  (is (= "2021 május 20" (call-fn "date" "hu" "YYYY MMMM d", "2021-05-20"))))
+  (letfn [(date [& args] (.call io.github.erdos.stencil.functions.DateFunctions/DATE  (to-array args)))]
+    (testing "two arguments"
+      (is (= "2021/05/20" (date "YYYY/MM/d", "2021-05-20")))
+      (is (= nil (date nil, "2021-05-20")))
+      (is (= nil (date "YYYY/MM/d", nil))))
+    (testing "three arguments"
+      (is (= "2021 május 20" (date "hu" "YYYY MMMM d", "2021-05-20")))
+      (is (= nil (date "hu" nil, "2021-05-20")))
+      (is (= nil (date "hu" "YYYY MMMM d", nil)))
+      (is (= nil (date nil "YYYY MMMM d", "2021-05-20"))))))
 
 (deftest test-map
   (testing "Empty input"

--- a/test/stencil/functions_test.clj
+++ b/test/stencil/functions_test.clj
@@ -35,6 +35,14 @@
     (is (thrown? ExceptionInfo (call-fn "format" 34 1)))
     (is (thrown? ExceptionInfo (call-fn "format" nil 2)))))
 
+
+(defmethod call-fn "date" [_ & args]
+  (.call io.github.erdos.stencil.functions.DateFunctions/DATE  (to-array args)))
+
+(deftest test-date
+  (is (= "2021/05/20" (call-fn "date" "YYYY/MM/d", "2021-05-20")))
+  (is (= "2021 május 20" (call-fn "date" "hu" "YYYY MMMM d", "2021-05-20"))))
+
 (deftest test-map
   (testing "Empty input"
     (is (= [] (call-fn "map" "x" [])))


### PR DESCRIPTION
See Issue: https://github.com/erdos/stencil/issues/89

Adds a 3-arity version of `date()` function to render localized strings.