### PR TITLE
feat: array access operator

### DIFF
--- a/docs/Syntax.md
+++ b/docs/Syntax.md
@@ -25,6 +25,12 @@ After applying Stencil with input data `{"customerName": "John Doe"}` you get th
 
 <img src="screenshot-substitution-after.png"/>
 
+## Nested field access
+
+You can reference values from nested fields by writing a dot separator between the field names. For example: `customer.name` can be used to reference the value `"John"` in  `{"customer": {"name": "John"}}`
+
+When the field name contains special characters, it may not be possible to reference it in a syntactically correct way directly. In these cases, the special curly braces operator can be used for property access. Syntax is `field1[field2]`. The expression `field2` will also be evaluated, so you need to quote the expression if it is not a dynamic vale. For example: `customer['name']`.
+
 ## Control structures
 
 You can embed control structures in your templates to implement advanced

--- a/test/stencil/infix_test.clj
+++ b/test/stencil/infix_test.clj
@@ -122,10 +122,12 @@
   (is (= 6 (run "(a)[1]"   {"a" {"1" 6}})))
 
   (testing "multiple expressions"
-    (is (= 7 (run "a[a[1]+4]" {"a" {"1" 2 "6" 7}}))))
+    (is (= 7 (run "a[a[1]+4]" {"a" {"1" 2 "6" 7}})))
+    (is (= 8 (run "a[1][2]" {"a" {"1" {"2" 8}}}))))
 
   (testing "syntax error"
     (is (thrown? ExceptionInfo (run "[3]" {})))
+    (is (thrown? ExceptionInfo (run "a[[3]]" {})))
     (is (thrown? ExceptionInfo (run "a[1,2]" {}))))
 
   (testing "key is missing from input"


### PR DESCRIPTION
Add the new  bracket operator to access fields with unexpected syntax.

Example: Use `a['x-y']` to access `a.x-y`.