### PR TITLE
fix: lookup arity

### DIFF
--- a/test/stencil/eval_test.clj
+++ b/test/stencil/eval_test.clj
@@ -44,7 +44,7 @@
     (test-eval [{:cmd :echo :expression '[1 2 :plus]}]
                [{:text "3"}]))
   (testing "Nested data access with path"
-    (test-eval [{:cmd :echo :expression '[abc.def]}]
+    (test-eval [{:cmd :echo :expression '[abc "def" :get]}]
                [{:text "Okay"}])))
 
 (deftest test-for

--- a/test/stencil/infix_test.clj
+++ b/test/stencil/infix_test.clj
@@ -138,6 +138,7 @@
 
   (testing "syntax error"
     (is (thrown? ExceptionInfo (run "[3]" {})))
+    (is (thrown? ExceptionInfo (run "a..b" {})))
     (is (thrown? ExceptionInfo (run "a[[3]]" {})))
     (is (thrown? ExceptionInfo (run "a[1,2]" {}))))
 

--- a/test/stencil/infix_test.clj
+++ b/test/stencil/infix_test.clj
@@ -46,7 +46,7 @@
 
   (testing "Simple values"
     (is (= [12] (infix/parse "  12 ") (infix/parse "12")))
-    (is (= '[ax.y] (infix/parse "   ax.y  "))))
+    (is (= '[ax "y" :get] (infix/parse "   ax.y  "))))
 
   (testing "Simple operations"
     (is (= [1 2 :plus]
@@ -131,6 +131,10 @@
   (testing "multiple expressions"
     (is (= 7 (run "a[a[1]+4]" {"a" {"1" 2 "6" 7}})))
     (is (= 8 (run "a[1][2]" {"a" {"1" {"2" 8}}}))))
+
+  (testing "mixed lookup"
+    (is (= 7 (run "a['x'].y" {"a" {"x" {"y" 7}}})))
+    (is (= 8 (run "a.x['y']" {"a" {"x" {"y" 8}}}))))
 
   (testing "syntax error"
     (is (thrown? ExceptionInfo (run "[3]" {})))


### PR DESCRIPTION
stencil throws an exception when access with `[]` and with dotted form is mixed in a single expression, like in `x[y].z`.

TODO:
- [ ] check if it breaks variable name enumeration