### PR TITLE
fix: merger substring exception

### DIFF
--- a/src/stencil/merger.clj
+++ b/src/stencil/merger.clj
@@ -31,7 +31,7 @@
   (assert (string? s))
   (let [ind        (.indexOf s (str open-tag))]
     (when-not (neg? ind)
-      (let [after-idx  (.indexOf s (str close-tag))]
+      (let [after-idx  (.indexOf s (str close-tag) ind)]
         (if (neg? after-idx)
           (cond-> {:action-part (.substring s (+ ind (count open-tag)))}
             (not (zero? ind)) (assoc :before (.substring s 0 ind)))

--- a/test/stencil/merger_test.clj
+++ b/test/stencil/merger_test.clj
@@ -90,7 +90,7 @@
 
 (defmacro are+ [argv [& exprs] & bodies] (list* 'do (for [e exprs] `(are ~argv ~e ~@bodies))))
 
-(def O1 {:open 1})
+(def O1 {:open 1}) (def C1 {:close 1})
 (def O2 {:open 2})
 (def O3 {:open 3})
 (def O4 {:open 4})
@@ -126,4 +126,9 @@
             [{:text "abc{"} O1 {:text "%"} O2 {:text "=1"} O3 {:text "2"} O4 {:text "%"} O5 {:text "}"} {:text "b"}]
             [{:text "abc"} {:text "{"} O1 {:text "%"} O2 {:text "=1"} O3 {:text "2"} O4 {:text "%"} O5 {:text "}"} {:text "b"}]
             [{:text "abc"} {:action {:cmd :echo, :expression [12]}} O1 O2 O3 O4 O5 {:text "b"}]
+
+            ;; TODO: this is failing!
+            [O1 {:text "{%if p"} C1 O1 {:text "%}one{%end%}"} C1]
+            [O1 {:text "{%if p"} C1 O1 {:text "%}one{%end%}"} C1]
+            [O1 {:action {:cmd :if, :condition '[p]}} C1 O1 {:text "one"} {:action {:cmd :end}} C1]           
             ))))

--- a/test/stencil/merger_test.clj
+++ b/test/stencil/merger_test.clj
@@ -90,7 +90,7 @@
 
 (defmacro are+ [argv [& exprs] & bodies] (list* 'do (for [e exprs] `(are ~argv ~e ~@bodies))))
 
-(def O1 {:open 1}) (def C1 {:close 1})
+(def O1 {:open 1})
 (def O2 {:open 2})
 (def O3 {:open 3})
 (def O4 {:open 4})
@@ -127,7 +127,7 @@
             [{:text "abc"} {:text "{"} O1 {:text "%"} O2 {:text "=1"} O3 {:text "2"} O4 {:text "%"} O5 {:text "}"} {:text "b"}]
             [{:text "abc"} {:action {:cmd :echo, :expression [12]}} O1 O2 O3 O4 O5 {:text "b"}]
 
-            [O1 {:text "{%if p"} C1 O1 {:text "%}one{%end%}"} C1]
-            [O1 {:text "{%if p"} C1 O1 {:text "%}one"} {:text "{%end%}"} C1]
-            [O1 {:action {:cmd :if, :condition '[p]}} C1 O1 {:text "one"} {:action {:cmd :end}} C1]           
+            [O1 {:text "{%if p"} O2 O3 {:text "%}one{%end%}"} O4]
+            [O1 {:text "{%if p"} O2 O3 {:text "%}one"} {:text "{%end%}"} O4]
+            [O1 {:action {:cmd :if, :condition '[p]}} O2 O3 {:text "one"} {:action {:cmd :end}} O4]           
             ))))

--- a/test/stencil/merger_test.clj
+++ b/test/stencil/merger_test.clj
@@ -127,8 +127,7 @@
             [{:text "abc"} {:text "{"} O1 {:text "%"} O2 {:text "=1"} O3 {:text "2"} O4 {:text "%"} O5 {:text "}"} {:text "b"}]
             [{:text "abc"} {:action {:cmd :echo, :expression [12]}} O1 O2 O3 O4 O5 {:text "b"}]
 
-            ;; TODO: this is failing!
             [O1 {:text "{%if p"} C1 O1 {:text "%}one{%end%}"} C1]
-            [O1 {:text "{%if p"} C1 O1 {:text "%}one{%end%}"} C1]
+            [O1 {:text "{%if p"} C1 O1 {:text "%}one"} {:text "{%end%}"} C1]
             [O1 {:action {:cmd :if, :condition '[p]}} C1 O1 {:text "one"} {:action {:cmd :end}} C1]           
             ))))


### PR DESCRIPTION
There is a bug in the merger algorithm causing some templates to crash stencil.

It is a miracle it has not came up earlier.