### PR TITLE
fix: fragments dropped environment

### DIFF
--- a/src/stencil/ooxml.clj
+++ b/src/stencil/ooxml.clj
@@ -25,6 +25,12 @@
 ;; Content Break: http://officeopenxml.com/WPtextSpecialContent-break.php
 (def br :xmlns.http%3A%2F%2Fschemas.openxmlformats.org%2Fwordprocessingml%2F2006%2Fmain/br)
 
+;; TODO what is this for? ezt kene hasznalni br page helyett? >_-ovvo-_<
+(def last-rendered-page-break :xmlns.http%3A%2F%2Fschemas.openxmlformats.org%2Fwordprocessingml%2F2006%2Fmain/lastRenderedPageBreak)
+
+;; TODO: es ezek mik?
+;;  w:rsidR="00F979C3" w:rsidRPr="002A24B2"
+
 (def type :xmlns.http%3A%2F%2Fschemas.openxmlformats.org%2Fwordprocessingml%2F2006%2Fmain/type)
 
 (def w :xmlns.http%3A%2F%2Fschemas.openxmlformats.org%2Fwordprocessingml%2F2006%2Fmain/w)

--- a/src/stencil/ooxml.clj
+++ b/src/stencil/ooxml.clj
@@ -25,12 +25,6 @@
 ;; Content Break: http://officeopenxml.com/WPtextSpecialContent-break.php
 (def br :xmlns.http%3A%2F%2Fschemas.openxmlformats.org%2Fwordprocessingml%2F2006%2Fmain/br)
 
-;; TODO what is this for? ezt kene hasznalni br page helyett? >_-ovvo-_<
-(def last-rendered-page-break :xmlns.http%3A%2F%2Fschemas.openxmlformats.org%2Fwordprocessingml%2F2006%2Fmain/lastRenderedPageBreak)
-
-;; TODO: es ezek mik?
-;;  w:rsidR="00F979C3" w:rsidRPr="002A24B2"
-
 (def type :xmlns.http%3A%2F%2Fschemas.openxmlformats.org%2Fwordprocessingml%2F2006%2Fmain/type)
 
 (def w :xmlns.http%3A%2F%2Fschemas.openxmlformats.org%2Fwordprocessingml%2F2006%2Fmain/w)

--- a/src/stencil/postprocess/fragments.clj
+++ b/src/stencil/postprocess/fragments.clj
@@ -102,8 +102,7 @@
 
         (zip/remove))))
 
-;; return loc of first p? idk
-;; chunk-loc must be in a <T> node.
+
 (defn- split-paragraphs [chunk-loc & insertable-paragraphs]
   (let [p-left (-> chunk-loc
                    (remove-all-rights)

--- a/src/stencil/postprocess/fragments.clj
+++ b/src/stencil/postprocess/fragments.clj
@@ -54,7 +54,7 @@
               text (:content run)
               :when (map? text)
               :when (= ooxml/t (:tag text))
-              c (:content run)
+              c (:content text)
               :when (string? c)
               :when (not-empty c)] c))))
 
@@ -102,7 +102,8 @@
 
         (zip/remove))))
 
-
+;; return loc of first p? idk
+;; chunk-loc must be in a <T> node.
 (defn- split-paragraphs [chunk-loc & insertable-paragraphs]
   (let [p-left (-> chunk-loc
                    (remove-all-rights)

--- a/test/stencil/postprocess/fragments_test.clj
+++ b/test/stencil/postprocess/fragments_test.clj
@@ -1,0 +1,28 @@
+(ns stencil.postprocess.fragments-test
+  (:require [clojure.test :refer [deftest testing is are]]
+            [clojure.zip :as zip]
+            [stencil.ooxml :as ooxml]
+            [stencil.util :refer [find-first-in-tree xml-zip]]
+            [stencil.postprocess.fragments :refer :all]))
+
+;; make all private vars public!
+(let [target (the-ns 'stencil.postprocess.fragments)]
+  (doseq [[k v] (ns-map target)
+          :when (and (var? v) (= target (.ns ^clojure.lang.Var v)))]
+    (eval `(defn ~(symbol (str "-" k)) [~'& args#] (apply (deref ~v) args#)))))
+
+
+(defn- p [& xs] {:tag ooxml/p :content xs})
+(defn- r [& xs] {:tag ooxml/r :content xs})
+(defn- t [& xs] {:tag ooxml/t :content xs})
+
+;; TODO: before-after are gone!
+(deftest test-split-paragraphs-1
+  (let [data {:tag :root :content [(p (r (t "hello" :HERE) (t "vilag")))]}
+        loc (find-first-in-tree #{:HERE} (xml-zip data))]
+    (-> loc
+        (doto assert)
+        (-split-paragraphs (p (r (t "one"))) (p (r (t "two"))))
+        (zip/root)
+        ; (zip/node)
+        (->> (println :!!!)))))

--- a/test/stencil/postprocess/fragments_test.clj
+++ b/test/stencil/postprocess/fragments_test.clj
@@ -5,18 +5,12 @@
             [stencil.util :refer [find-first-in-tree xml-zip]]
             [stencil.postprocess.fragments :refer :all]))
 
-;; make all private vars public!
-(let [target (the-ns 'stencil.postprocess.fragments)]
-  (doseq [[k v] (ns-map target)
-          :when (and (var? v) (= target (.ns ^clojure.lang.Var v)))]
-    (eval `(defn ~(symbol (str "-" k)) [~'& args#] (apply (deref ~v) args#)))))
+(defn- p [& xs] {:tag ooxml/p :content (vec xs)})
+(defn- r [& xs] {:tag ooxml/r :content (vec xs)})
+(defn- t [& xs] {:tag ooxml/t :content (vec xs)})
 
+(def -split-paragraphs @#'stencil.postprocess.fragments/split-paragraphs)
 
-(defn- p [& xs] {:tag ooxml/p :content xs})
-(defn- r [& xs] {:tag ooxml/r :content xs})
-(defn- t [& xs] {:tag ooxml/t :content xs})
-
-;; TODO: before-after are gone!
 (deftest test-split-paragraphs-1
   (let [data {:tag :root :content [(p (r (t "hello" :HERE) (t "vilag")))]}
         loc (find-first-in-tree #{:HERE} (xml-zip data))]
@@ -24,5 +18,8 @@
         (doto assert)
         (-split-paragraphs (p (r (t "one"))) (p (r (t "two"))))
         (zip/root)
-        ; (zip/node)
-        (->> (println :!!!)))))
+        (= {:tag :root
+             :content [(p (r (t "hello"))) ;; before
+                       (p (r (t "one"))) (p (r (t "two"))) ;; newly inserted
+                       (p (r (t) (t "vilag")))]}) ;; after
+        (is))))


### PR DESCRIPTION
text runs were droppen when they were in the same `w:p` elem where the fragment include expression was.