### PR TITLE
fix: nonbreaking space in control

### DIFF
--- a/src/stencil/infix.clj
+++ b/src/stencil/infix.clj
@@ -2,7 +2,7 @@
   "Parsing and evaluating infix algebraic expressions.
 
   https://en.wikipedia.org/wiki/Shunting-yard_algorithm"
-  (:require [stencil.util :refer [fail update-peek ->int string]]
+  (:require [stencil.util :refer [fail update-peek ->int string whitespace?]]
             [stencil.log :as log]
             [stencil.functions :refer [call-fn]]))
 
@@ -117,7 +117,7 @@
       (empty? characters)
       tokens
 
-      (contains? #{\space \tab \newline} first-char)
+      (whitespace? first-char)
       (recur next-chars tokens)
 
       (contains? #{\, \;} first-char)

--- a/src/stencil/postprocess/list_ref.clj
+++ b/src/stencil/postprocess/list_ref.clj
@@ -3,6 +3,7 @@
             [stencil.ooxml :as ooxml]
             [stencil.model.numbering :as numbering]
             [stencil.log :as log]
+            [clojure.string]
             [clojure.zip :as zip]))
 
 (set! *warn-on-reflection* true)
@@ -175,7 +176,7 @@
 
 (defn parse-instr-text [^String s]
   (assert (string? s))
-  (let [[type id & flags] (vec (.split (.trim s) "\\s\\\\?+"))]
+  (let [[type id & flags] (vec (.split (trim s) "\\s\\\\?+"))]
     (when (= "REF" type)
       {:id id
        :flags (set (map keyword flags))})))

--- a/src/stencil/tokenizer.clj
+++ b/src/stencil/tokenizer.clj
@@ -1,16 +1,16 @@
 (ns stencil.tokenizer
   "Fog egy XML dokumentumot es tokenekre bontja"
   (:require [clojure.data.xml :as xml]
-            [clojure.string :refer [includes? split trim]]
+            [clojure.string :refer [includes? split]]
             [stencil.infix :as infix]
             [stencil.types :refer [open-tag close-tag]]
-            [stencil.util :refer [assoc-if-val mod-stack-top-conj mod-stack-top-last parsing-exception]]))
+            [stencil.util :refer [assoc-if-val mod-stack-top-conj mod-stack-top-last parsing-exception trim]]))
 
 (set! *warn-on-reflection* true)
 
 (defn- text->cmd-impl [^String text]
   (assert (string? text))
-  (let [text (.trim text)
+  (let [text (trim text)
         pattern-elseif #"^(else\s*if|elif|elsif)(\(|\s+)"]
     (cond
       (#{"end" "endfor" "endif"} text) {:cmd :end}

--- a/src/stencil/util.clj
+++ b/src/stencil/util.clj
@@ -126,4 +126,22 @@
   ([values] (apply str values))
   ([xform coll] (transduce xform (fn ([^Object s] (.toString s)) ([^StringBuilder b v] (.append b v))) (StringBuilder.) coll)))
 
+(defn ^{:inline (fn [c] `(case ~c (\tab \space \newline
+                                   \u00A0 \u2007 \u202F ;; non-breaking spaces
+                                   \u000B \u000C \u000D \u001C \u001D \u001E \u001F)
+                            true false))} 
+  whitespace? [c] (whitespace? c))
+
+;; like clojure.string/trim but supports more whitespace characters
+(defn ^String trim [^CharSequence s]
+  (loop [right-idx (.length s)]
+    (if (zero? right-idx)
+      ""
+      (if (whitespace? (.charAt s (dec right-idx)))
+        (recur (dec right-idx))
+        (loop [left-idx 0]
+          (if (whitespace? (.charAt s left-idx))
+            (recur (inc left-idx))
+            (.toString (.subSequence s left-idx right-idx))))))))
+
 :OK

--- a/src/stencil/util.clj
+++ b/src/stencil/util.clj
@@ -132,7 +132,7 @@
                             true false))} 
   whitespace? [c] (whitespace? c))
 
-;; like clojure.string/trim but supports more whitespace characters
+;; like clojure.string/trim but supports a wider range of whitespace characters
 (defn ^String trim [^CharSequence s]
   (loop [right-idx (.length s)]
     (if (zero? right-idx)

--- a/test/stencil/tokenizer_test.clj
+++ b/test/stencil/tokenizer_test.clj
@@ -34,7 +34,7 @@
 
 (deftest read-tokens-if-then
   (testing "Simple conditional with THEN branch only"
-    (is (= (run "<a>elotte {% if x%} akkor {% end %} utana</a>")
+    (is (= (run "<a>elotte {% if x%} akkor {% end %} utana</a>")
            [{:open :a}
             {:text "elotte "}
             {:cmd :if :condition '(x)}

--- a/test/stencil/util_test.clj
+++ b/test/stencil/util_test.clj
@@ -1,5 +1,5 @@
 (ns stencil.util-test
-  (:require [clojure.test :refer [deftest testing is]]
+  (:require [clojure.test :refer [deftest testing is are]]
             [clojure.zip :as zip]
             [stencil.util :refer :all]))
 
@@ -110,3 +110,10 @@
   (is (= true (whitespace? \tab)))
   (is (= false (whitespace? " ")))
   (is (= false (whitespace? \A))))
+
+(deftest trim-test
+  (are [input] (= "" (trim input))
+    "", " ", "\t\t\n") 
+  (are [input] (= "abc" (trim input))
+    "abc", "    abc", "abc   ", " \t  \n abc \t")
+  (is (= "a b c" (trim "  a b c  \t"))))

--- a/test/stencil/util_test.clj
+++ b/test/stencil/util_test.clj
@@ -104,3 +104,9 @@
 (deftest suffixes-test
   (is (= [] (suffixes []) (suffixes nil)))
   (is (= [[1 2 3] [2 3] [3]] (suffixes [1 2 3]))))
+
+(deftest whitespace?-test
+  (is (= true (whitespace? \space)))
+  (is (= true (whitespace? \tab)))
+  (is (= false (whitespace? " ")))
+  (is (= false (whitespace? \A))))


### PR DESCRIPTION
As mentioned in  https://github.com/erdos/stencil/issues/139#issuecomment-1321698516

> The most nasty issue we've got probably. We've had a long DOCX template which included {% end %} tag that contained a Non-breaking space between d and % which failed the rendering. It was only returning stencil.exceptions.ParsingException: Unexpected command I believe.

Apparently, `java.lang.Character/isWhitespace` is `false` for non-breaking whitepsace and therefore `java.lang.String/trim` also does not work on it. It produces cryptic error messages so lets fix it properly.