### PR TITLE
functions provider SPI

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -1,5 +1,6 @@
 (ns build
-  (:require [clojure.tools.build.api :as b]
+  (:require [clojure.java.io :as io]
+            [clojure.tools.build.api :as b]
             [clojure.tools.build.util.file :as file]))
 
 (def build-folder "target")
@@ -29,6 +30,14 @@
             :javac-opts ["-source" "8" "-target" "8"]})
   (b/copy-file {:src "java-src/io/github/erdos/stencil/standalone/help.txt"
                 :target "target/classes/io/github/erdos/stencil/standalone/help.txt"})
+
+  ;; generate service provider config for function providers
+  (let [services (io/file "target/classes/META-INF/services/io.github.erdos.stencil.functions.FunctionsProvider")]
+    (io/make-parents services)
+    (doseq [f (file-seq (clojure.java.io/file jar-content))
+            [_ a] (re-seq #"^target/classes/(.*\$Provider).class$" (str f))
+            :let [clazz (str (.replace a "/" ".") "\n")]]
+      (spit services, clazz :append true)))
   (spit (str jar-content "/stencil-version") version)
   opts)
 

--- a/docs/Functions.md
+++ b/docs/Functions.md
@@ -233,7 +233,9 @@ Expects one number argument containing a list with numbers. Sums up the numbers 
 
 ## Custom functions
 
-You can register custom implementations of `io.github.erdos.stencil.functions.Function` or the `stencil.functions/call-fn` multimethod.
+You can register custom implementations of `io.github.erdos.stencil.functions.Function` or the `stencil.functions/call-fn` multimethod.  
+If you implement the `call-fn` multimethod, the namespace containing these implementations should be loaded before rendering a document.  
+(Keep in mind, that `call-fn` implementations always have priority over `io.github.erdos.stencil.functions.Function` implementations)
 
 Clojure example:
 
@@ -271,3 +273,10 @@ public class FirstFuncion implements Function {
 
 API.render(preparedTemplate, fragments, data, Arrays.asList(new FirstFunction()));
 ```
+
+
+### Automatic registration of custom functions
+
+Stencil uses the JVM's [ServiceLoader](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) facility to load function provider implementations.
+If you want to register your custom functions automatically, implement the `io.github.erdos.stencil.functions.FunctionsProvider` interface,
+and add these implementations to your extension library's `META-INF/services/io.github.erdos.stencil.functions.FunctionsProvider` file.

--- a/java-src/io/github/erdos/stencil/API.java
+++ b/java-src/io/github/erdos/stencil/API.java
@@ -6,6 +6,7 @@ import io.github.erdos.stencil.impl.NativeTemplateFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 
@@ -59,7 +60,7 @@ public final class API {
     public static EvaluatedDocument render(PreparedTemplate template, Map<String, PreparedFragment> fragments, TemplateData data, Collection<Function> customFunctions) {
         FunctionEvaluator function = new FunctionEvaluator();
         if (customFunctions != null) {
-            function.registerFunctions(customFunctions.toArray(new Function[0]));
+            function.registerFunctions(() -> new ArrayList<>(customFunctions));
         }
         return template.render(fragments, function, data);
     }

--- a/java-src/io/github/erdos/stencil/API.java
+++ b/java-src/io/github/erdos/stencil/API.java
@@ -6,7 +6,6 @@ import io.github.erdos.stencil.impl.NativeTemplateFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 
@@ -60,7 +59,7 @@ public final class API {
     public static EvaluatedDocument render(PreparedTemplate template, Map<String, PreparedFragment> fragments, TemplateData data, Collection<Function> customFunctions) {
         FunctionEvaluator function = new FunctionEvaluator();
         if (customFunctions != null) {
-            function.registerFunctions(() -> new ArrayList<>(customFunctions));
+            function.registerFunctions(customFunctions.toArray(new Function[0]));
         }
         return template.render(fragments, function, data);
     }

--- a/java-src/io/github/erdos/stencil/functions/BasicFunctions.java
+++ b/java-src/io/github/erdos/stencil/functions/BasicFunctions.java
@@ -1,5 +1,6 @@
 package io.github.erdos.stencil.functions;
 
+import java.util.Arrays;
 import java.util.Collection;
 
 /**
@@ -71,5 +72,12 @@ public enum BasicFunctions implements Function {
     @Override
     public String getName() {
         return name().toLowerCase();
+    }
+
+    public static class Provider implements FunctionsProvider {
+        @Override
+        public Iterable<Function> functions() {
+            return Arrays.asList(values());
+        }
     }
 }

--- a/java-src/io/github/erdos/stencil/functions/DateFunctions.java
+++ b/java-src/io/github/erdos/stencil/functions/DateFunctions.java
@@ -8,10 +8,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.Optional;
+import java.util.*;
 
 import static java.util.Arrays.asList;
 import static java.util.Locale.forLanguageTag;
@@ -135,5 +132,12 @@ public enum DateFunctions implements Function {
     @Override
     public String getName() {
         return name().toLowerCase();
+    }
+
+    public static class Provider implements FunctionsProvider {
+        @Override
+        public Iterable<Function> functions() {
+            return Arrays.asList(values());
+        }
     }
 }

--- a/java-src/io/github/erdos/stencil/functions/DateFunctions.java
+++ b/java-src/io/github/erdos/stencil/functions/DateFunctions.java
@@ -8,7 +8,10 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.util.*;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
 
 import static java.util.Arrays.asList;
 import static java.util.Locale.forLanguageTag;
@@ -137,7 +140,7 @@ public enum DateFunctions implements Function {
     public static class Provider implements FunctionsProvider {
         @Override
         public Iterable<Function> functions() {
-            return Arrays.asList(values());
+            return asList(values());
         }
     }
 }

--- a/java-src/io/github/erdos/stencil/functions/FunctionsProvider.java
+++ b/java-src/io/github/erdos/stencil/functions/FunctionsProvider.java
@@ -1,0 +1,5 @@
+package io.github.erdos.stencil.functions;
+
+public interface FunctionsProvider {
+    Iterable<Function> functions();
+}

--- a/java-src/io/github/erdos/stencil/functions/LocaleFunctions.java
+++ b/java-src/io/github/erdos/stencil/functions/LocaleFunctions.java
@@ -1,6 +1,7 @@
 package io.github.erdos.stencil.functions;
 
 import java.text.NumberFormat;
+import java.util.Arrays;
 import java.util.Locale;
 
 import static java.util.Locale.forLanguageTag;
@@ -52,5 +53,12 @@ public enum LocaleFunctions implements Function {
     @Override
     public String getName() {
         return name().toLowerCase();
+    }
+
+    public static class Provider implements FunctionsProvider {
+        @Override
+        public Iterable<Function> functions() {
+            return Arrays.asList(values());
+        }
     }
 }

--- a/java-src/io/github/erdos/stencil/functions/NumberFunctions.java
+++ b/java-src/io/github/erdos/stencil/functions/NumberFunctions.java
@@ -1,5 +1,7 @@
 package io.github.erdos.stencil.functions;
 
+import java.util.Arrays;
+
 /**
  * Common numeric functions.
  */
@@ -71,6 +73,13 @@ public enum NumberFunctions implements Function {
             throw new IllegalArgumentException("The function expects a number argument!");
         } else {
             return (Number) arguments[0];
+        }
+    }
+
+    public static class Provider implements FunctionsProvider {
+        @Override
+        public Iterable<Function> functions() {
+            return Arrays.asList(values());
         }
     }
 }

--- a/java-src/io/github/erdos/stencil/functions/StringFunctions.java
+++ b/java-src/io/github/erdos/stencil/functions/StringFunctions.java
@@ -112,4 +112,11 @@ public enum StringFunctions implements Function {
     public String getName() {
         return name().toLowerCase();
     }
+
+    public static class Provider implements FunctionsProvider {
+        @Override
+        public Iterable<Function> functions() {
+            return Arrays.asList(values());
+        }
+    }
 }


### PR DESCRIPTION
Reimplements https://github.com/erdos/stencil/pull/138 

and resolves conflicts with code changed in the meanwhile. We aim to keep the code simpler this time:

- no function priorities - to keep code simple. We do not allow overriding of functions (by same name) but instead just throw an exception when function with same name already exists.
- small footprint in code diff (ideally below 100 LOC)
- automatic configuration generation (in META-INF)

Scenarios to manually test:
- [x] java functions available in clj unit tests
- [x] available in standalone mode (uberjar)
- [ ] available when stencil is used as a library (jar)
- [ ] available in standalone mode compiled with GraalVM native-image
- [ ] available when ran as docker service
- [ ] available when ran in native docker service
