### PR TITLE
fix: content types of extra files

### DIFF
--- a/src/stencil/model/content_types.clj
+++ b/src/stencil/model/content_types.clj
@@ -37,8 +37,21 @@
      :stencil.model/path       (.getName cts)}))
 
 
+(defn- extra-file-overrides [model]
+  (for [section [[(-> model :main)]
+                 (-> model :main :headers+footers)
+                 (-> model :main :stencil.model/slide-layouts)]
+        part    section
+        :when   (:stencil.model/path part)
+        [_ rel] (-> part :relations :parsed)
+        :when   (:stencil.model/mime-type rel)]
+    [(str "/" (fs/unix-path (fs/unroll (file (fs/parent-file (file (:stencil.model/path part)))
+                                             (:stencil.model/target rel)))))
+     (:stencil.model/mime-type rel)]))
+
 (defn with-content-types [model]
   (let [parsed (-> model :content-types :parsed)
+        parsed (update parsed ::override into (extra-file-overrides model))
         tree   {:tag tag-types
                 :attrs {:xmlns xmlns}
                 :content (concat (for [[k v] (::default parsed)]

--- a/src/stencil/ooxml.clj
+++ b/src/stencil/ooxml.clj
@@ -129,6 +129,9 @@
    "http://schemas.microsoft.com/office/powerpoint/2012/main"            "p15"
    })
 
+;; extension list, used for SVG image reference inside a blip
+(def ext-lst :xmlns.http%3A%2F%2Fschemas.openxmlformats.org%2Fdrawingml%2F2006%2Fmain/extLst)
+
 ;; drawing, binary large image or picture
 (def blip :xmlns.http%3A%2F%2Fschemas.openxmlformats.org%2Fdrawingml%2F2006%2Fmain/blip)
 ;; hyperlinks

--- a/src/stencil/postprocess/images.clj
+++ b/src/stencil/postprocess/images.clj
@@ -83,6 +83,7 @@
     {:new-id               new-rel
      :stencil.model/type   relations/rel-type-image
      :stencil.model/target (image-path new-rel mime-type)
+     :stencil.model/mime-type mime-type
      :writer               (bytes->writer bytes)}))
 
 ;; replaces the nearest image with the content

--- a/src/stencil/postprocess/images.clj
+++ b/src/stencil/postprocess/images.clj
@@ -48,7 +48,11 @@
         new-val     (-> data .relation)]
     (assert new-val)
     (log/debug "Replacing image relation {} by {}" current-rel new-val)
-    (assoc-in img-node [:attrs attr-key] new-val)))
+    (-> img-node
+        (assoc-in [:attrs attr-key] new-val)
+        ; If placeholder has an SVG graphic, remove so the replacement raster image is used directly:
+        (update :content #(remove (comp #{ooxml/ext-lst} :tag) %)))))
+
 
 (defn- replace-image [marker-loc]
   (if-let [img-loc (->> (zip/remove marker-loc)


### PR DESCRIPTION
When extra files are added to the template during evaluation (for example, with `replaceImage()` calls), these are not present in the `[Content_Types].xml` file.

## Severity

Rarely causes problem if the CT XML has defaults for the extra file extension.